### PR TITLE
Remove jobsub_client and ifdhc from the setup script. They need to oc…

### DIFF
--- a/RawData/classes_def.xml
+++ b/RawData/classes_def.xml
@@ -6,7 +6,8 @@
 <lcgdict>
   <class name="std::vector<int16_t>"                  />
   <class name="std::vector<int32_t>"                  />
-  <class name="emph::rawdata::SSDRawDigit"    ClassVersion="12" >
+  <class name="emph::rawdata::SSDRawDigit"    ClassVersion="13" >
+   <version ClassVersion="13" checksum="2743877428"/>
    <version ClassVersion="12" checksum="543454205"/>
    <version ClassVersion="11" checksum="995705853"/>
   </class>
@@ -14,7 +15,8 @@
    <version ClassVersion="12" checksum="1710862163"/>
    <version ClassVersion="11" checksum="4069590048"/>
   </class>
-  <class name="emph::rawdata::TRB3RawDigit"    ClassVersion="12" >
+  <class name="emph::rawdata::TRB3RawDigit"    ClassVersion="13" >
+   <version ClassVersion="13" checksum="1560633629"/>
    <version ClassVersion="12" checksum="441560763"/>
    <version ClassVersion="11" checksum="441560763"/>
   </class>

--- a/setup/setup_emphatic.sh
+++ b/setup/setup_emphatic.sh
@@ -104,5 +104,3 @@ export SSL_CERT_FILE=""
 setup ninja
 setup libwda v2_29_1
 setup art_cpp_db_interfaces v1_4_0
-setup jobsub_client
-setup ifdhc

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -325,7 +325,12 @@ end_qualifier_list
 # Table fragment.
 #
 ####################################
-
+table_fragment_begin
+# setup the products used by emphaticsoft that do not have any qualifiers
+# make the setup optional in case running on a machine where these
+# products are not installed - they are not needed for code development
+    setupOptional( fife_utils )
+table_fragment_end
 ####################################
 
 ####################################


### PR DESCRIPTION
…cur after external products have been setup in order to avoid a python skew. I need to add back in ifdhc appropriately but nobody is using it atm. Sort that tomorrow.

increment version number for classes_def of RawData products.