### PR TITLE
Remove reconfigure(). This function was deprecated years ago and keep…

### DIFF
--- a/ARICHReco/ARICHReco_module.cc
+++ b/ARICHReco/ARICHReco_module.cc
@@ -46,10 +46,7 @@ namespace emph {
     
     // Optional, read/write access to event
     void produce(art::Event& evt);
-    
-    // Optional if you want to be able to configure from event display, for example
-    void reconfigure(const fhicl::ParameterSet& pset);
-    
+        
     // Optional use if you have histograms, ntuples, etc you want around for every event
     void beginJob();
     //void endRun(art::Run const&);
@@ -74,7 +71,6 @@ namespace emph {
 
     this->produces< std::vector<rb::ARing>>();
 
-    //this->reconfigure(pset);
     fEvtNum = 0;
 
   }
@@ -90,12 +86,6 @@ namespace emph {
 
   //......................................................................
 
-  // void ARICHReco::reconfigure(const fhicl::ParameterSet& pset)
-  // {    
-  // }
-
-  //......................................................................
-  
   void ARICHReco::beginJob()
   {
     art::ServiceHandle<art::TFileService> tfs;

--- a/BACkovHitReco/BACkovHitReco_module.cc
+++ b/BACkovHitReco/BACkovHitReco_module.cc
@@ -47,9 +47,6 @@ namespace emph {
     // Optional, read/write access to event
     void produce(art::Event& evt);
     
-    // Optional if you want to be able to configure from event display, for example
-    void reconfigure(const fhicl::ParameterSet& pset);
-    
     // Optional use if you have histograms, ntuples, etc you want around for every event
     void beginJob();
     //void endRun(art::Run const&);
@@ -61,7 +58,7 @@ namespace emph {
 
     art::ServiceHandle<emph::cmap::ChannelMapService> cmap;
     
-    int mom;
+    int mom; // This should really be pulled from SpillInfo instead of set in the fcl.
     std::vector<std::vector<int>> BACkov_signal;
     std::vector<std::vector<int>> PID_table; //in the form {e,mu,pi,k,p} w/ {1,1,0,0,0} being e/mu are possible particles
     int pid_num;
@@ -76,12 +73,11 @@ namespace emph {
   //.......................................................................
   
   BACkovHitReco::BACkovHitReco(fhicl::ParameterSet const& pset)
-    : EDProducer(pset)
+    : EDProducer(pset),
+      mom (pset.get<int>("momentum",0))
   {
 
     this->produces< std::vector<rb::BACkovHit>>();
-
-    this->reconfigure(pset);
 
   }
 
@@ -92,13 +88,6 @@ namespace emph {
     //======================================================================
     // Clean up any memory allocated by your module
     //======================================================================
-  }
-
-  //......................................................................
-
-  void BACkovHitReco::reconfigure(const fhicl::ParameterSet& pset)
-  {
-    mom = pset.get<int>("momentum",0);
   }
 
   //......................................................................

--- a/ChannelMap/service/ChannelMapService.cc
+++ b/ChannelMap/service/ChannelMapService.cc
@@ -20,10 +20,9 @@ namespace emph
     
     //------------------------------------------------------------
     ChannelMapService::ChannelMapService(const fhicl::ParameterSet& pset,
-					 art::ActivityRegistry & reg)
+					 art::ActivityRegistry & reg):
+      fAbortIfFileNotFound (pset.get<bool>("AbortIfFileNotFound"))      
     {
-      reconfigure(pset);
-      
       art::ServiceHandle<runhist::RunHistoryService> rhs;
 
       fChannelMap = new ChannelMap();
@@ -37,13 +36,7 @@ namespace emph
     ChannelMapService::~ChannelMapService()
     {
     }
-    
-    //-----------------------------------------------------------
-    void ChannelMapService::reconfigure(const fhicl::ParameterSet& pset)
-    {
-      fAbortIfFileNotFound = pset.get<bool>("AbortIfFileNotFound");
-    }
-    
+        
     //----------------------------------------------------------
     void ChannelMapService::preBeginRun(const art::Run& )
     {

--- a/ChannelMap/service/ChannelMapService.h
+++ b/ChannelMap/service/ChannelMapService.h
@@ -33,8 +33,6 @@ namespace emph
 			art::ActivityRegistry& reg);
       virtual ~ChannelMapService();
       
-      void reconfigure(const fhicl::ParameterSet& pset);
-    
       void preBeginRun(const art::Run& run);
 
       DChannel DetChan(EChannel echan) { return fChannelMap->DetChan(echan); }

--- a/ChannelState/service/ChannelStateService.cc
+++ b/ChannelState/service/ChannelStateService.cc
@@ -16,10 +16,16 @@ namespace emph
 {
   //------------------------------------------------------------
   ChannelStateService::ChannelStateService(const fhicl::ParameterSet& pset,
-					   art::ActivityRegistry & reg)
+					   art::ActivityRegistry & reg):
+    fLoadSSDFromDB   (pset.get<bool>("LoadSSDFromDB")),
+    fLoadARICHFromDB (pset.get<bool>("LoadARICHFromDB")),
+    fCondbURL        (pset.get<std::string>("CondbURL"))
+
   {
-    reconfigure(pset);
-    
+    fChannelState->SetLoadSSDFromDB(fLoadSSDFromDB);
+    fChannelState->SetLoadARICHFromDB(fLoadARICHFromDB);
+    fChannelState->SetCondbURL(fCondbURL);
+
     fChannelState = new ChannelState();
     fChannelState->SetDataType("data");
 
@@ -31,14 +37,6 @@ namespace emph
   
   ChannelStateService::~ChannelStateService()
   {
-  }
-  
-  //-----------------------------------------------------------
-  void ChannelStateService::reconfigure(const fhicl::ParameterSet& pset)
-  {
-    fChannelState->SetLoadSSDFromDB(pset.get<bool>("LoadSSDFromDB"));
-    fChannelState->SetLoadARICHFromDB(pset.get<bool>("LoadARICHFromDB"));
-    fChannelState->SetCondbURL(pset.get<std::string>("CondbURL"));
   }
   
   //----------------------------------------------------------

--- a/ChannelState/service/ChannelStateService.h
+++ b/ChannelState/service/ChannelStateService.h
@@ -40,6 +40,9 @@ namespace emph
     
   private:
     ChannelState* fChannelState;
+    bool fLoadSSDFromDB;
+    bool fLoadARICHFromDB;
+    std::string fCondbURL;
     
   };
   

--- a/Demo/DemoModule_module.cc
+++ b/Demo/DemoModule_module.cc
@@ -37,9 +37,6 @@ namespace demo {
       // Optional, read/write access to event
       void produce(art::Event& evt); 
 
-      // Optional if you want to be able to configure from event display, for example
-      void reconfigure(const fhicl::ParameterSet& pset);
-
       // Optional use if you have histograms, ntuples, etc you want around for every event
       void beginJob();
       
@@ -62,7 +59,13 @@ namespace demo
 {
   //.......................................................................
   DemoModule::DemoModule(fhicl::ParameterSet const& pset) 
-    : EDProducer(pset)
+    : EDProducer(pset),
+      fInt              (pset.get< int              >("MyInt")),
+      fVecInt           (pset.get< std::vector<int> >("MyVectorInt")),
+      fFloat            (pset.get< float            >("MyFloat")),
+      fDouble           (pset.get< double           >("MyDouble")),
+      fInputModuleLabel (pset.get< std::string      >("MyInputModuleLabel"))
+
   {
     //======================================================================
     // This is the constructor "nova" will use to create your module.
@@ -76,8 +79,6 @@ namespace demo
     // file.
     //======================================================================
 
-    this->reconfigure(pset);
-    
     // tell the module what it is making as this is a EDProducer
     produces< std::vector<int> >();
 
@@ -93,17 +94,6 @@ namespace demo
     //======================================================================
   }
 
-  //......................................................................
-  void DemoModule::reconfigure(const fhicl::ParameterSet& pset)
-  {
-    // Keep everything lined up for clarity (stylistic)
-    fInt              = pset.get< int              >("MyInt");
-    fVecInt           = pset.get< std::vector<int> >("MyVectorInt");
-    fFloat            = pset.get< float            >("MyFloat");
-    fDouble           = pset.get< double           >("MyDouble");
-    fInputModuleLabel = pset.get< std::string      >("MyInputModuleLabel");
-  }
-      
   //......................................................................
   void DemoModule::beginJob()
   {

--- a/Demo/templates/Template.cxx
+++ b/Demo/templates/Template.cxx
@@ -23,18 +23,11 @@ namespace NAMESPACE
   //.......................................................................
   MODULENAME::MODULENAME(const fhicl::ParameterSet& pset)
   {
-    reconfigure(pset);
-
     //    produces< std::vector<int> >();
   }
 
   //......................................................................
   MODULENAME::~MODULENAME()
-  {
-  }
-
-  //......................................................................
-  void MODULENAME::reconfigure(const fhicl::ParameterSet& pset)
   {
   }
 

--- a/Demo/templates/Template.h
+++ b/Demo/templates/Template.h
@@ -20,8 +20,6 @@ namespace NAMESPACE
 
     void produce(art::Event& evt);
 
-    void reconfigure(const fhicl::ParameterSet& pset);
-
     void beginJob();
 
   protected:

--- a/Demo/tmp/TutProducer_module.cc
+++ b/Demo/tmp/TutProducer_module.cc
@@ -35,8 +35,6 @@ namespace tut
 
     void produce(art::Event& evt);
 
-    void reconfigure(const fhicl::ParameterSet& pset);
-
     void beginJob();
 
   protected:
@@ -53,23 +51,17 @@ namespace tut
 {
   //.......................................................................
   TutProducer::TutProducer(const fhicl::ParameterSet& pset)
-  : EDProducer(pset)
+    : EDProducer(pset),
+      fGeantLabel   (pset.get<std::string>("GeantLabel")),
+      fCellHitLabel (pset.get<std::string>("CellHitLabel"))
+      
   {
-    reconfigure(pset);
-
     produces<std::vector<rb::Prong> >();
   }
 
   //......................................................................
   TutProducer::~TutProducer()
   {
-  }
-
-  //......................................................................
-  void TutProducer::reconfigure(const fhicl::ParameterSet& pset)
-  {
-    fGeantLabel = pset.get<std::string>("GeantLabel");
-    fCellHitLabel = pset.get<std::string>("CellHitLabel");
   }
 
   //......................................................................

--- a/DetGeoMap/service/DetGeoMapService.cc
+++ b/DetGeoMap/service/DetGeoMapService.cc
@@ -19,11 +19,12 @@ namespace emph
     
     //------------------------------------------------------------
     DetGeoMapService::DetGeoMapService(const fhicl::ParameterSet& pset,
-					 art::ActivityRegistry & reg)
+				       art::ActivityRegistry & reg):
+      fUseGeometry (pset.get<bool>("UseGeometry"))
     {
       fDetGeoMap = new DetGeoMap();
-      reconfigure(pset);
-      
+      fDetGeoMap->SetUseGeometry(fUseGeometry);
+
       reg.sPreBeginRun.watch(this, &DetGeoMapService::preBeginRun);
 
     }
@@ -32,12 +33,6 @@ namespace emph
     
     DetGeoMapService::~DetGeoMapService()
     {
-    }
-    
-    //-----------------------------------------------------------
-    void DetGeoMapService::reconfigure(const fhicl::ParameterSet& pset)
-    {
-      fDetGeoMap->SetUseGeometry(pset.get<bool>("UseGeometry"));
     }
     
     //----------------------------------------------------------

--- a/DetGeoMap/service/DetGeoMapService.h
+++ b/DetGeoMap/service/DetGeoMapService.h
@@ -43,6 +43,7 @@ namespace emph
       
     private:
       DetGeoMap* fDetGeoMap;
+      bool fUseGeometry;
       
     };
     

--- a/Digitization/SSDDigitizer_module.cc
+++ b/Digitization/SSDDigitizer_module.cc
@@ -49,9 +49,6 @@ namespace emph {
     
     void produce(art::Event& evt);
     
-    // Optional if you want to be able to configure from event display, for example
-    void reconfigure(const fhicl::ParameterSet& pset);
-    
     // Optional use if you have histograms, ntuples, etc you want around for every event
     //    void beginJob();
     //    void beginRun(art::Run const&);
@@ -87,11 +84,10 @@ namespace emph {
   
   //.......................................................................
   SSDDigitizer::SSDDigitizer(fhicl::ParameterSet const& pset)
-    : EDProducer(pset)
+    : EDProducer(pset),
+      fG4Label (pset.get<std::string>("G4Label"))
   {
     //    fEvent = 0;
-    this->reconfigure(pset);
-
     fSensorMap.clear();
 
     produces<std::vector<rawdata::SSDRawDigit> >("SSD");
@@ -109,15 +105,6 @@ namespace emph {
 
   //......................................................................
 
-  void SSDDigitizer::reconfigure(const fhicl::ParameterSet& pset)
-  {
-    fG4Label = pset.get<std::string>("G4Label");
-
-    //    fMakeSSDTree = pset.get<bool>("MakeSSDTree"); 
-  }
-
-  //......................................................................
-  
   void SSDDigitizer::FillSensorMap()
   {
     art::ServiceHandle<emph::cmap::ChannelMapService> cmap;

--- a/G4EMPH/AnalyzeSSDHitsWithTracks_module.cc
+++ b/G4EMPH/AnalyzeSSDHitsWithTracks_module.cc
@@ -47,9 +47,6 @@ namespace emph {
       explicit AnalyzeSSDHitsWithTracks(fhicl::ParameterSet const& pset); // Required!       // Optional, read/write access to event
       void analyze(const art::Event& evt);
 
-      // Optional if you want to be able to configure from event display, for example
-      void reconfigure(const fhicl::ParameterSet& pset);
-
       // Optional use if you have histograms, ntuples, etc you want around for every event
       void beginJob();
       void beginRun(art::Run const&);
@@ -97,25 +94,21 @@ namespace emph {
     
 // .....................................................................................
     AnalyzeSSDHitsWithTracks::AnalyzeSSDHitsWithTracks(fhicl::ParameterSet const& pset) : 
-    EDAnalyzer(pset), 
-    fFilesAreOpen(false), fDoPResol1Stu(false), fDoMult2Stu(false), fTokenJob("undef"), fSSDHitLabel("?"), fTrackLabel("?"),
-     fRun(0), fSubRun(0),  fEvtNum(INT_MAX), fNEvents(0) , fPitch(0.06),
-     fRunHistory(nullptr), fEmgeo(nullptr), fEmSSDHits(nullptr), fEmTracks(nullptr), 
-     fZlocXPlanes(0), fZlocXStations(0), fZlocYPlanes(0), fZlocYStations(0) 
+      EDAnalyzer(pset), 
+      fFilesAreOpen(false),
+      fDoPResol1Stu (pset.get<bool>("doPresol1Stu", false)),
+      fDoMult2Stu   (pset.get<bool>("doMult2Stu", false)),
+      fTokenJob     (pset.get<std::string>("tokenJob", "UnDef")),
+      fSSDHitLabel  (pset.get<std::string>("SSDHitLabel")),
+      fTrackLabel   (pset.get<std::string>("TrackLabel")),
+      fRun(0), fSubRun(0),  fEvtNum(INT_MAX), fNEvents(0) , fPitch(0.06),
+      fRunHistory(nullptr), fEmgeo(nullptr), fEmSSDHits(nullptr), fEmTracks(nullptr), 
+      fZlocXPlanes(0), fZlocXStations(0), fZlocYPlanes(0), fZlocYStations(0)
     {
        std::cerr << " Constructing AnalyzeSSDHitsWithTracks " << std::endl;
-       this->reconfigure(pset);
        fFilesAreOpen = false;
     }
     
-    void AnalyzeSSDHitsWithTracks::reconfigure(const fhicl::ParameterSet& pset)
-    {
-      fTokenJob = pset.get<std::string>("tokenJob", "UnDef");
-      fDoPResol1Stu = pset.get<bool>("doPresol1Stu", false);
-      fDoMult2Stu = pset.get<bool>("doMult2Stu", false);
-     fSSDHitLabel = pset.get<std::string>("SSDHitLabel");
-      fTrackLabel = pset.get<std::string>("TrackLabel");
-    }
     void AnalyzeSSDHitsWithTracks::beginRun(art::Run const &run)
     {
      std::cerr << " AnalyzeSSDHitsWithTracks::beginRun, run " << run.id() << std::endl;

--- a/GasCherenkov/GasCkovAna.fcl
+++ b/GasCherenkov/GasCkovAna.fcl
@@ -5,9 +5,7 @@ BEGIN_PROLOG
 standard_gasckovana:
 {
  module_type:		GasCkovAna
- ADCThresh0:            0.
- ADCThresh1:            0.
- ADCThresh2:            0.
+ ADCThresh:             [0., 0., 0.]
 }
 
 END_PROLOG

--- a/GasCherenkov/GasCkovAna_module.cc
+++ b/GasCherenkov/GasCkovAna_module.cc
@@ -42,9 +42,6 @@ namespace emph {
     // Optional, read/write access to event
     void analyze(const art::Event& evt);
     
-    // Optional if you want to be able to configure from event display, for example
-    void reconfigure(const fhicl::ParameterSet& pset);
-    
     // Optional use if you have histograms, ntuples, etc you want around for every event
     void beginJob();
     void beginSubRun(const art::SubRun& sr);
@@ -77,7 +74,7 @@ namespace emph {
     float pressure6a;
     float pressure6b;
     float efficiency;
-    float adcThresh[3];
+    std::vector<float> adcThresh;
 
     // define histograms and tree
     TH1F* fGasCkovADCDist[nChanGasCkov];
@@ -86,11 +83,9 @@ namespace emph {
   };  
   //.......................................................................
   GasCkovAna::GasCkovAna(fhicl::ParameterSet const& pset)
-    : EDAnalyzer(pset)
+    : EDAnalyzer(pset),
+      adcThresh (pset.get< std::vector<float> >("ADCThresh"))
   {
-
-    this->reconfigure(pset);
-
   }
 
   //......................................................................
@@ -99,15 +94,6 @@ namespace emph {
     //======================================================================
     // Clean up any memory allocated by your module
     //======================================================================
-  }
-
-  //......................................................................
-  void GasCkovAna::reconfigure(const fhicl::ParameterSet& pset)
-  {
-    adcThresh[0] = pset.get<double>("ADCThresh0",0.);
-    adcThresh[1] = pset.get<double>("ADCThresh1",0.);
-    adcThresh[2] = pset.get<double>("ADCThresh2",0.);
-
   }
 
   //......................................................................
@@ -205,7 +191,7 @@ namespace emph {
 	if (detchan >= 0 && detchan < nchan) {
 	  float adc = wvfm.Baseline()-wvfm.PeakADC();
 	  float blw = wvfm.BLWidth();
-	  if ((adc > 5*blw) && (adc > adcThresh[detchan])){
+	  if ((adc > 5*blw) && (adc > adcThresh.at(detchan))){
 	    if (detchan == 0) pmtadc1 = adc;
 	    if (detchan == 1) pmtadc2 = adc;
 	    if (detchan == 2) pmtadc3 = adc;

--- a/GasCkovHitReco/GasCkovHitReco_module.cc
+++ b/GasCkovHitReco/GasCkovHitReco_module.cc
@@ -47,9 +47,6 @@ namespace emph {
     // Optional, read/write access to event
     void produce(art::Event& evt);
     
-    // Optional if you want to be able to configure from event display, for example
-    void reconfigure(const fhicl::ParameterSet& pset);
-    
     // Optional use if you have histograms, ntuples, etc you want around for every event
     void beginJob();
     //void endRun(art::Run const&);
@@ -61,7 +58,7 @@ namespace emph {
 
     art::ServiceHandle<emph::cmap::ChannelMapService> cmap;
     
-    int mom;
+    int mom; // This should really be pulled from SpillInfo instead of set in the fcl.
     std::vector<std::vector<int>> GasCkov_signal;
     std::vector<std::vector<int>> PID_table; //in the form {e,mu,pi,k,p} w/ {1,1,0,0,0} being e/mu are possible particles
     int pid_num;
@@ -76,12 +73,11 @@ namespace emph {
   //.......................................................................
   
   GasCkovHitReco::GasCkovHitReco(fhicl::ParameterSet const& pset)
-    : EDProducer(pset)
+    : EDProducer(pset),
+      mom (pset.get<int>("momentum",0))
   {
 
     this->produces< std::vector<rb::GasCkovHit>>();
-
-    this->reconfigure(pset);
 
   }
 
@@ -92,15 +88,6 @@ namespace emph {
     //======================================================================
     // Clean up any memory allocated by your module
     //======================================================================
-  }
-
-  //......................................................................
-
-  void GasCkovHitReco::reconfigure(const fhicl::ParameterSet& pset)
-  {
-    
-    mom = pset.get<int>("momentum",0);
-    
   }
 
   //......................................................................

--- a/Geometry/service/GeometryService.h
+++ b/Geometry/service/GeometryService.h
@@ -30,8 +30,6 @@ namespace emph
 			art::ActivityRegistry& reg);
       virtual ~GeometryService();
       
-      void reconfigure(const fhicl::ParameterSet& pset);
-    
       void preBeginRun(const art::Run& run);
 
       emph::geo::Geometry* Geo() const { return fGeometry.get(); }

--- a/Geometry/service/Geometry_service.cc
+++ b/Geometry/service/Geometry_service.cc
@@ -25,8 +25,6 @@ namespace emph
       TGeoManager::SetDefaultUnits(TGeoManager::EDefaultUnits::kRootUnits);
       TGeoManager::LockDefaultUnits(1);
 
-      reconfigure(pset);
-      
       art::ServiceHandle<runhist::RunHistoryService> rhs;
 
       reg.sPreBeginRun.watch(this, &GeometryService::preBeginRun);
@@ -40,12 +38,6 @@ namespace emph
     }
     
     //-----------------------------------------------------------
-    void GeometryService::reconfigure(const fhicl::ParameterSet& )//pset)
-    {
-
-    }
-    
-    //----------------------------------------------------------
     // If we have run-dependent geometry, do something here to reload
     // the geometry if necessary
     //----------------------------------------------------------

--- a/MCValidation/G4EMPHValidate_module.cc
+++ b/MCValidation/G4EMPHValidate_module.cc
@@ -46,9 +46,6 @@ namespace emph {
     
     void analyze(const art::Event& evt);
     
-    // Optional if you want to be able to configure from event display, for example
-    void reconfigure(const fhicl::ParameterSet& pset);
-    
     // Optional use if you have histograms, ntuples, etc you want around for every event
     void beginJob();
     //    void beginRun(art::Run const&);
@@ -75,11 +72,10 @@ namespace emph {
   
   //.......................................................................
   G4EMPHValidate::G4EMPHValidate(fhicl::ParameterSet const& pset)
-    : EDAnalyzer(pset)
+    : EDAnalyzer(pset),
+      fMakeSSDTree (pset.get<bool>("MakeSSDTree"))
   {
     fEvent = 0;
-    this->reconfigure(pset);
-
   }
 
   //......................................................................
@@ -89,13 +85,6 @@ namespace emph {
     //======================================================================
     // Clean up any memory allocated by your module
     //======================================================================
-  }
-
-  //......................................................................
-
-  void G4EMPHValidate::reconfigure(const fhicl::ParameterSet& pset)
-  {
-    fMakeSSDTree = pset.get<bool>("MakeSSDTree"); 
   }
 
   //......................................................................

--- a/MagneticField/service/MagneticFieldService.h
+++ b/MagneticField/service/MagneticFieldService.h
@@ -27,8 +27,6 @@ namespace emph
 			 art::ActivityRegistry& reg);
     virtual ~MagneticFieldService();
     
-    void reconfigure(const fhicl::ParameterSet& pset);
-    
     void preBeginRun(const art::Run& run);
     
     emph::EMPHATICMagneticField* Field() const { return fMagneticField; }

--- a/MagneticField/service/MagneticField_service.cc
+++ b/MagneticField/service/MagneticField_service.cc
@@ -16,10 +16,9 @@ namespace emph
 {
   //------------------------------------------------------------
   MagneticFieldService::MagneticFieldService(const fhicl::ParameterSet& pset,
-				   art::ActivityRegistry & reg)
+					     art::ActivityRegistry & reg):
+    fFieldFileName (pset.get< std::string >("FieldFileName"))
   {
-
-    reconfigure(pset);
 /*
     Jonathan decided to by-pass the fcl .. 
     Not sure this is the best option.. Paul Lebrun, Oct 20 2022. 
@@ -53,14 +52,6 @@ namespace emph
   }
   
   //-----------------------------------------------------------
-  void MagneticFieldService::reconfigure(const fhicl::ParameterSet& pset)
-  {
-    
-    fFieldFileName = pset.get< std::string >("FieldFileName");
-    
-  }
-  
-  //----------------------------------------------------------
   // If we have run-dependent field, do something here to reload
   // the field if necessary
   //----------------------------------------------------------

--- a/OnlineMonitoring/plotter/OnMonPlotter_module.cc
+++ b/OnlineMonitoring/plotter/OnMonPlotter_module.cc
@@ -66,9 +66,6 @@ namespace emph {
       // Optional, read/write access to event
       void analyze(const art::Event& evt);
 
-      // Optional if you want to be able to configure from event display, for example
-      void reconfigure(const fhicl::ParameterSet& pset);
-
       // Optional use if you have histograms, ntuples, etc you want around for every event
       void beginJob();
       void beginRun(art::Run const& /*run*/);
@@ -199,37 +196,21 @@ namespace emph {
 
     //.......................................................................
     OnMonPlotter::OnMonPlotter(fhicl::ParameterSet const& pset)
-      : EDAnalyzer(pset)
+      : EDAnalyzer(pset),
+	fSHMname           (pset.get<std::string>("SHMHandle")),
+	fuseSHM            (pset.get<bool>("useSHM")),
+	fTickerOn          (pset.get<bool>("TickerOn")),
+	fMakeWaveFormPlots (pset.get<bool>("makeWaveFormPlots",true)),
+	fMakeTRB3Plots     (pset.get<bool>("makeTRB3Plots",true)),
+	fMakeSSDPlots      (pset.get<bool>("makeSSDPlots",false))
     {
 
-      this->reconfigure(pset);
       HistoTable::Instance(Settings::Instance().fCSVFile.c_str(),
 		       Settings::Instance().fDet);
-
-    }
-
-    //......................................................................
-    OnMonPlotter::~OnMonPlotter()
-    {
-      //======================================================================
-      // Clean up any memory allocated by your module
-      //======================================================================
-    }
-
-    //......................................................................
-    void OnMonPlotter::reconfigure(const fhicl::ParameterSet& pset)
-    {
-      fSHMname = pset.get<std::string>("SHMHandle");
-      fuseSHM = pset.get<bool>("useSHM");
-      fTickerOn = pset.get<bool>("TickerOn");
 
       //if (fIPC) delete fIPC;
       if (fuseSHM) fIPC = new OnMonProdIPC(kIPC_SERVER, fSHMname.c_str());
       else fIPC = nullptr;
-
-      fMakeWaveFormPlots = pset.get<bool>("makeWaveFormPlots",true);
-      fMakeTRB3Plots = pset.get<bool>("makeTRB3Plots",true);
-      fMakeSSDPlots = pset.get<bool>("makeSSDPlots",false);
       
       // try to find the correct path to the .csv file.
       std::string filename = pset.get< std::string > ("CSVFile");
@@ -251,6 +232,15 @@ namespace emph {
       } // loop on directory attempts
 
       Settings::Instance().fDet = kEMPH;
+
+    }
+
+    //......................................................................
+    OnMonPlotter::~OnMonPlotter()
+    {
+      //======================================================================
+      // Clean up any memory allocated by your module
+      //======================================================================
     }
 
     //......................................................................

--- a/RunHistory/service/RunHistoryService.cc
+++ b/RunHistory/service/RunHistoryService.cc
@@ -14,9 +14,11 @@ namespace runhist
 {
   //------------------------------------------------------------
   RunHistoryService::RunHistoryService(const fhicl::ParameterSet& pset,
-				       art::ActivityRegistry & reg)
+				       art::ActivityRegistry & reg):
+    fLoadFromDB (pset.get<bool>("LoadFromDB"))
   {
-    reconfigure(pset);
+    if (fLoadFromDB)
+      fQEURL = pset.get<std::string>("QEURL");
 
     reg.sPreBeginRun.watch(this, &RunHistoryService::preBeginRun);
     
@@ -26,15 +28,6 @@ namespace runhist
   
   RunHistoryService::~RunHistoryService()
   {
-  }
-  
-  //-----------------------------------------------------------
-  void RunHistoryService::reconfigure(const fhicl::ParameterSet& pset)
-  {
-    fLoadFromDB = pset.get<bool>("LoadFromDB");
-    if (fLoadFromDB)
-      fQEURL = pset.get<std::string>("QEURL");
-    
   }
   
   //----------------------------------------------------------

--- a/RunHistory/service/RunHistoryService.h
+++ b/RunHistory/service/RunHistoryService.h
@@ -32,8 +32,6 @@ namespace runhist
 		      art::ActivityRegistry& reg);
     virtual ~RunHistoryService();
     
-    void reconfigure(const fhicl::ParameterSet& pset);
-    
     void preBeginRun(const art::Run& run);
     
     runhist::RunHistory* RunHist() const { return fRunHistory.get(); }

--- a/SSDAlignment/SSDAlignment_module.cc
+++ b/SSDAlignment/SSDAlignment_module.cc
@@ -53,9 +53,6 @@ namespace emph {
     // Optional, read/write access to event
     void produce(art::Event& evt);
     
-    // Optional if you want to be able to configure from event display, for example
-    void reconfigure(const fhicl::ParameterSet& pset);
-    
     // Optional use if you have histograms, ntuples, etc you want around for every event
     void beginJob();
     void beginRun(art::Run& run);
@@ -88,7 +85,6 @@ namespace emph {
   SSDAlignment::SSDAlignment(fhicl::ParameterSet const& pset)
     : EDProducer(pset)
   {
-    //this->reconfigure(pset);
     evt_disp = new TGraph*[10];
     evt_disp_adj = new TGraph*[10];
     fEvtNum = 0;
@@ -106,12 +102,6 @@ namespace emph {
 
   //......................................................................
 
-  // void SSDAlignment::reconfigure(const fhicl::ParameterSet& pset)
-  // {    
-  // }
- 
-  //......................................................................
-  
   void SSDAlignment::beginJob()
   {
 	char hname[64];

--- a/SSDCalibration/SSDCalibration_module.cc
+++ b/SSDCalibration/SSDCalibration_module.cc
@@ -49,9 +49,6 @@ namespace emph {
     // Optional, read/write access to event
     void produce(art::Event& evt);
     
-    // Optional if you want to be able to configure from event display, for example
-    void reconfigure(const fhicl::ParameterSet& pset);
-    
     // Optional use if you have histograms, ntuples, etc you want around for every event
     //    void beginRun(art::Run& run);
     //      void endSubRun(art::SubRun const&);
@@ -76,7 +73,6 @@ namespace emph {
 
     //    this->produces<std::vector<rb::ARing>>();
 
-    //this->reconfigure(pset);
     fEvtNum = 0;
 
   }
@@ -89,12 +85,6 @@ namespace emph {
     // Clean up any memory allocated by your module
     //======================================================================
   }
-
-  //......................................................................
-
-  // void SSDCalibration::reconfigure(const fhicl::ParameterSet& pset)
-  // {    
-  // }
 
   //......................................................................
   

--- a/SSDCalibration/SSDHotChannels_module.cc
+++ b/SSDCalibration/SSDHotChannels_module.cc
@@ -63,9 +63,6 @@ namespace emph {
     // Optional, read/write access to event
     void analyze(const art::Event& evt);
     
-    // Optional if you want to be able to configure from event display, for example
-    void reconfigure(const fhicl::ParameterSet& pset);
-    
     // Optional use if you have histograms, ntuples, etc you want around for every event
     //    void beginRun(art::Run& run);
     //      void endSubRun(art::SubRun const&);
@@ -100,11 +97,12 @@ namespace emph {
   //.......................................................................
   
   SSDHotChannels::SSDHotChannels(fhicl::ParameterSet const& pset)
-    : EDAnalyzer(pset), fNumStrips(639), fTokenJob("undef"), fSkipHalfEvts(false), 
+    : EDAnalyzer(pset), fNumStrips(639), 
+      fTokenJob     (pset.get<std::string>("tokenJob", "UnDef")),
+      fSkipHalfEvts (pset.get<bool>("skipHalfEvts", false)),
       fRun(0), fSubRun(-1), fEvtNum(0), fNEvents(0), fHists(0)
   {
 
-    this->reconfigure(pset);
     for (int kSt = 0; kSt !=6; kSt++) {
       for (int kSe = 0; kSe !=6; kSe++) {
         SSDHotChannels::ChanHist  aHist(kSt, kSe); 
@@ -124,16 +122,6 @@ namespace emph {
 
   //......................................................................
 
-  void SSDHotChannels::reconfigure(const fhicl::ParameterSet& pset)
-  {  
-       
-      std::cerr << " emph::SSDHotChannels::reconfigure ... " <<std::endl;
-      fTokenJob = pset.get<std::string>("tokenJob", "UnDef");
-      fSkipHalfEvts = pset.get<bool>("skipHalfEvts", false);
-  }
-
-  //......................................................................
-  
   //  void SSDHotChannels::beginRun(art::Run& run)
   //  {
   // initialize channel map

--- a/SSDReco/RecoBeamTracksAlgo1_module.cc
+++ b/SSDReco/RecoBeamTracksAlgo1_module.cc
@@ -61,9 +61,7 @@ namespace emph {
       RecoBeamTracksAlgo1& operator=(RecoBeamTracksAlgo1 const&) = delete;
       RecoBeamTracksAlgo1& operator=(RecoBeamTracksAlgo1&&) = delete;
 
-
-      // Optional if you want to be able to configure from event display, for example
-      void reconfigure(const fhicl::ParameterSet& pset);
+      void setupAlignAlgs(const fhicl::ParameterSet& pset);
 
       // Optional use if you have histograms, ntuples, etc you want around for every event
       void beginJob();
@@ -130,41 +128,35 @@ namespace emph {
     
 // .....................................................................................
     emph::RecoBeamTracksAlgo1::RecoBeamTracksAlgo1(fhicl::ParameterSet const& pset) : 
-    EDProducer(pset), 
-    fFilesAreOpen(false), fTokenJob("undef"), fSSDClsLabel("?"),
-    fSelectHotChannelsFromHits(true),     
-    fDoAlignUV(true),  
-    fDoSkipDeadOrHotStrips(true),
-    fRun(0), fSubRun(0),  fEvtNum(INT_MAX), fNEvents(0) , fPitch(0.06),
-    fNumMaxIterAlignAlgo1(10), fChiSqCutAlignAlgo1(20.), fSetMCRMomentum(120.),
-     fRunHistory(nullptr), fEmgeo(nullptr), 
-     fZlocXPlanes(0), fZlocYPlanes(0), fZlocUPlanes(0), fZlocVPlanes(0)
+      EDProducer(pset), 
+      fFilesAreOpen(false),
+      fTokenJob    (pset.get<std::string>("tokenJob", "UnDef")),
+      fSSDClsLabel (pset.get<std::string>("SSDClsLabel")),
+      fSelectHotChannelsFromHits (pset.get<bool>("selectHotChannelsFromHits", true)),
+      fDoAlignUV (pset.get<bool>("alignUV", true)),
+      fDoSkipDeadOrHotStrips (pset.get<bool>("skipDeadOrHotStrips", false)),
+      fRun(0), fSubRun(0),  fEvtNum(INT_MAX), fNEvents(0) , fPitch(0.06),
+      fNumMaxIterAlignAlgo1 (pset.get<int>("NumMaxIterAlignAlgo1", 1000)),
+      fChiSqCutAlignAlgo1 (pset.get<double>("ChiSqCutAlignAlgo1", 1000.)),
+      fSetMCRMomentum (pset.get<double>("SetMCRMomentum", 120.)),
+      fRunHistory(nullptr), fEmgeo(nullptr), 
+      fZlocXPlanes(0), fZlocYPlanes(0), fZlocUPlanes(0), fZlocVPlanes(0)
     {
        std::cerr << " Constructing RecoBeamTracksAlgo1 " << std::endl;
-       this->reconfigure(pset);
+       this->setupAlignAlgs(pset);
        fFilesAreOpen = false;
 //       fSSDClsPtr = nullptr;
        fRMSClusterCuts = std::vector<double>{-1.0, 5.};
        this->produces< std::vector<rb::BeamTrackAlgo1> >();
     }
     
-    void emph::RecoBeamTracksAlgo1::reconfigure(const fhicl::ParameterSet& pset)
+    void emph::RecoBeamTracksAlgo1::setupAlignAlgs(const fhicl::ParameterSet& pset)
     {
-      std::cerr << " emph::RecoBeamTracksAlgo1::reconfigure ... " <<std::endl;
-      fSSDClsLabel = pset.get<std::string>("SSDClsLabel");   
-      std::cerr << "  ... fSSDClsLabel " << fSSDClsLabel << std::endl;   
-      fTokenJob = pset.get<std::string>("tokenJob", "UnDef");
-      fSelectHotChannelsFromHits = pset.get<bool>("selectHotChannelsFromHits", true);
       std::string fNameHCFH = pset.get<std::string>("NameFileHCFH", "./SSDCalibHotChanSummary_none_1055.txt");
       std::string fNameDCFH = pset.get<std::string>("NameFileHCFH", "./SSDCalibDeadChanSummary_none_1055.txt");
-      fDoAlignUV = pset.get<bool>("alignUV", true);
-      fDoSkipDeadOrHotStrips = pset.get<bool>("skipDeadOrHotStrips", false);
-      fNumMaxIterAlignAlgo1 = pset.get<int>("NumMaxIterAlignAlgo1", 1000);
-      fChiSqCutAlignAlgo1 = pset.get<double>("ChiSqCutAlignAlgo1", 1000.);
       double aChiSqCut3DUVXY = pset.get<double>("ChiSqCutAlign3DUVXY", 100.);
       double aChiSqCut3DUVUV = pset.get<double>("ChiSqCutAlign3DUVUV", 100.);
       const double aMagnetiKick = pset.get<double>("MagnetKick", -6.12e-4); 
-      fSetMCRMomentum = pset.get<double>("SetMCRMomentum", 120.);
       // default value for transverse (X) kick is for 120 GeV, assuming COMSOL file is correct. based on G4EMPH 
       std::vector<double> aZLocShifts = pset.get<std::vector<double> >("ZLocShifts", std::vector<double>(6, 0.));
       std::vector<double> aPitchAngles =  pset.get<std::vector<double> >("PitchAngles", std::vector<double>(6, 0.));
@@ -186,10 +178,10 @@ namespace emph {
 	  }
 	}
       }
-// 
-// set the  XY reconstructor and  U aligner. 
-//
-//      fAlignUV.SetZLocShifts(aZLocShifts);
+      // 
+      // set the  XY reconstructor and  U aligner. 
+      //
+      //fAlignUV.SetZLocShifts(aZLocShifts);
       fAlignUV.SetMagnetKick120GeV(aMagnetiKick);
       fAlignUV.SetOtherUncert(aTransUncert);
       fAlignUV.SetFittedResidualsForY(aMeanResidY);

--- a/SSDReco/StudyOneSSDClusters_module.cc
+++ b/SSDReco/StudyOneSSDClusters_module.cc
@@ -70,7 +70,7 @@ namespace emph {
 
 
       // Optional if you want to be able to configure from event display, for example
-      void reconfigure(const fhicl::ParameterSet& pset);
+      void setupAlignAlgs(const fhicl::ParameterSet& pset);
 
       // Optional use if you have histograms, ntuples, etc you want around for every event
       void beginJob();
@@ -159,51 +159,44 @@ namespace emph {
     
 // .....................................................................................
     emph::StudyOneSSDClusters::StudyOneSSDClusters(fhicl::ParameterSet const& pset) : 
-    EDAnalyzer(pset), 
-    fFilesAreOpen(false), fTokenJob("undef"), fSSDClsLabel("?"),
-    fDumpClusters(false), fSelectHotChannels(false), fSelectHotChannelsFromHits(false),     
-    fDoAlignX(false), fDoAlignY(false), fDoAlignUV(false), fDoGenCompact(false),
-    fDoAlignXAlt45(false), fDoAlignYAlt45(false), fDoAlignYAlt5(false), 
-     fDoSkipDeadOrHotStrips(true), fDoLastIs4AlignAlgo1(false),
-    fRun(0), fSubRun(0),  fEvtNum(INT_MAX), fNEvents(0) , fPitch(0.06),
-    fNumMaxIterAlignAlgo1(10), fChiSqCutAlignAlgo1(20.), fSetMCRMomentum(120.),
-     fRunHistory(nullptr), fEmgeo(nullptr), 
-     fZlocXPlanes(0), fZlocYPlanes(0), fZlocUPlanes(0), fZlocVPlanes(0)
+      EDAnalyzer(pset), 
+      fFilesAreOpen(false),
+      fTokenJob (pset.get<std::string>("tokenJob", "UnDef")),
+      fSSDClsLabel (pset.get<std::string>("SSDClsLabel")),
+      fDumpClusters (pset.get<bool>("dumpClusters", false)),
+      fSelectHotChannels (pset.get<bool>("selectHotChannels", false)),
+      fSelectHotChannelsFromHits (pset.get<bool>("selectHotChannelsFromHits", false)),
+      fDoAlignX (pset.get<bool>("alignX", false)),
+      fDoAlignY (pset.get<bool>("alignY", false)),
+      fDoAlignUV (pset.get<bool>("alignUV", false)),
+      fDoGenCompact (pset.get<bool>("genCompactEvts", false)),
+      fDoAlignXAlt45 (pset.get<bool>("alignXAlt45", false)),
+      fDoAlignYAlt45 (pset.get<bool>("alignYAlt45", false)),
+      fDoAlignYAlt5 (pset.get<bool>("alignYAlt5", false)),
+      fDoSkipDeadOrHotStrips (pset.get<bool>("skipDeadOrHotStrips", false)),
+      fDoLastIs4AlignAlgo1 (pset.get<bool>("LastIs4AlignAlgo1", false)),
+      fRun(0), fSubRun(0),  fEvtNum(INT_MAX), fNEvents(0) , fPitch(0.06),
+      fNumMaxIterAlignAlgo1 (pset.get<int>("NumMaxIterAlignAlgo1", 1000)),
+      fChiSqCutAlignAlgo1 (pset.get<double>("ChiSqCutAlignAlgo1", 1000.)),
+      fSetMCRMomentum (pset.get<double>("SetMCRMomentum", 120.)),
+      fRunHistory(nullptr), fEmgeo(nullptr), 
+      fZlocXPlanes(0), fZlocYPlanes(0), fZlocUPlanes(0), fZlocVPlanes(0)
     {
        std::cerr << " Constructing StudyOneSSDClusters " << std::endl;
-       this->reconfigure(pset);
+       this->setupAlignAlgs(pset);
        fFilesAreOpen = false;
 //       fSSDClsPtr = nullptr;
        fAlignX.SetTheView('X'); fAlignY.SetTheView('Y');
        fRMSClusterCuts = std::vector<double>{-1.0, 5.};
     }
     
-    void emph::StudyOneSSDClusters::reconfigure(const fhicl::ParameterSet& pset)
+    void emph::StudyOneSSDClusters::setupAlignAlgs(const fhicl::ParameterSet& pset)
     {
-      std::cerr << " emph::StudyOneSSDClusters::reconfigure ... " <<std::endl;
-      fSSDClsLabel = pset.get<std::string>("SSDClsLabel");   
-      std::cerr << "  ... fSSDClsLabel " << fSSDClsLabel << std::endl;   
-      fTokenJob = pset.get<std::string>("tokenJob", "UnDef");
-      fDumpClusters = pset.get<bool>("dumpClusters", false);
-      fSelectHotChannels = pset.get<bool>("selectHotChannels", false);
-      fSelectHotChannelsFromHits = pset.get<bool>("selectHotChannelsFromHits", false);
       std::string fNameHCFH = pset.get<std::string>("NameFileHCFH", "./SSDCalibHotChanSummary_none_1055.txt");
       std::string fNameDCFH = pset.get<std::string>("NameFileHCFH", "./SSDCalibDeadChanSummary_none_1055.txt");
-      fDoAlignX = pset.get<bool>("alignX", false);
-      fDoAlignY = pset.get<bool>("alignY", false);
-      fDoAlignUV = pset.get<bool>("alignUV", false);
-      fDoGenCompact = pset.get<bool>("genCompactEvts", false);
-      fDoAlignXAlt45 = pset.get<bool>("alignXAlt45", false);
-      fDoAlignYAlt45 = pset.get<bool>("alignYAlt45", false);
-      fDoAlignYAlt5 = pset.get<bool>("alignYAlt5", false);
-      fDoSkipDeadOrHotStrips = pset.get<bool>("skipDeadOrHotStrips", false);
-      fDoLastIs4AlignAlgo1 = pset.get<bool>("LastIs4AlignAlgo1", false);
-      fNumMaxIterAlignAlgo1 = pset.get<int>("NumMaxIterAlignAlgo1", 1000);
-      fChiSqCutAlignAlgo1 = pset.get<double>("ChiSqCutAlignAlgo1", 1000.);
       double aChiSqCut3DUVXY = pset.get<double>("ChiSqCutAlign3DUVXY", 100.);
       double aChiSqCut3DUVUV = pset.get<double>("ChiSqCutAlign3DUVUV", 100.);
       const double aMagnetiKick = pset.get<double>("MagnetKick", -6.12e-4); 
-      fSetMCRMomentum = pset.get<double>("SetMCRMomentum", 120.);
       // default value for transverse (X) kick is for 120 GeV, assuming COMSOL file is correct. based on G4EMPH 
       std::vector<double> aZLocShifts = pset.get<std::vector<double> >("ZLocShifts", std::vector<double>(6, 0.));
       std::vector<double> aPitchAngles =  pset.get<std::vector<double> >("PitchAngles", std::vector<double>(6, 0.));

--- a/TOF/LGCaloPrelimStudy_module.cc
+++ b/TOF/LGCaloPrelimStudy_module.cc
@@ -55,9 +55,6 @@ namespace emph {
       
   // Plugins should not be copied or assigned.
 
-      // Optional if you want to be able to configure from event display, for example
-      void reconfigure(const fhicl::ParameterSet& pset);
-
       // Optional use if you have histograms, ntuples, etc you want around for every event
       void beginJob();
       void endJob();
@@ -122,21 +119,21 @@ namespace emph {
     //.......................................................................
     LGCaloPrelimStudy::LGCaloPrelimStudy(fhicl::ParameterSet const& pset)
       : EDAnalyzer(pset),
-      fFilesAreOpen(false),
-      fTokenJob("none"),
-      fRun(0), fSubRun(0), fEvtNum(0), fNEvents(0), 
-      fBeamTrackLabel("beamTrackA"), fTrigToT0Label("trigT0A"),
-      fZMagnet(757.7), fZLG(2886.4),  fMagnetKick120GeV(-0.612e-3), // Should be replace by proper acces to the geometry.. 
-      fEffBeamMomentum(18.), // Set for run 1293, nominal P = 12 GeV, but magnet kick probably overestimated. 
-      fAmplTriggerCut{0., 5000.}, fAmplT0Cut{0., 250.}, 
-      fLGsAmpl(nChanLG+2, 0.), fLGA4IsSaturated(false)
+	fFilesAreOpen(false),
+	fTokenJob (pset.get<std::string>("tokenJob", "UnDef")),
+	fRun(0), fSubRun(0), fEvtNum(0), fNEvents(0), 
+	fBeamTrackLabel (pset.get<std::string>("BeamTrackLabel", "beamTrackA")),
+	fTrigToT0Label (pset.get<std::string>("TrigToT0Label", "trigT0A")),
+	fZMagnet(757.7), fZLG(2886.4),  fMagnetKick120GeV(-0.612e-3), // Should be replace by proper acces to the geometry.. 
+	fEffBeamMomentum (pset.get<double>("EffBeamMomentum", 18.)),
+	fAmplTriggerCut (pset.get<std::vector<double> >("AmplTriggerCut", std::vector<double> {0., 500000.})),
+	fAmplT0Cut (pset.get<std::vector<double> >("AmplT0Cut", std::vector<double> {0., 25000.} )),
+        fLGsAmpl(nChanLG+2, 0.), fLGA4IsSaturated(false)
     {
     
       fAmplTriggerCut[1] = 5000.;
       fAmplT0Cut[1] = 250.;
       
-      this->reconfigure(pset);
-
     }
     
     //......................................................................
@@ -148,17 +145,6 @@ namespace emph {
       //======================================================================
       // Clean up any memory allocated by your module
       //======================================================================
-    }
-
-    //......................................................................
-    void LGCaloPrelimStudy::reconfigure(const fhicl::ParameterSet& pset)
-    {
-      fTokenJob = pset.get<std::string>("tokenJob", "UnDef");
-      fBeamTrackLabel = pset.get<std::string>("BeamTrackLabel", "beamTrackA");
-      fTrigToT0Label = pset.get<std::string>("TrigToT0Label", "trigT0A");
-      fEffBeamMomentum = pset.get<double>("EffBeamMomentum", 18.);
-      fAmplTriggerCut = pset.get<std::vector<double> >("AmplTriggerCut", std::vector<double> {0., 500000.});
-      fAmplT0Cut = pset.get<std::vector<double> >("AmplT0Cut", std::vector<double> {0., 25000.} );
     }
 
     //......................................................................

--- a/TOF/T0toRPC_module.cc
+++ b/TOF/T0toRPC_module.cc
@@ -51,9 +51,6 @@ namespace emph {
       // Optional, read/write access to event
       void analyze(const art::Event& evt);
 
-      // Optional if you want to be able to configure from event display, for example
-      void reconfigure(const fhicl::ParameterSet& pset);
-
       // Optional use if you have histograms, ntuples, etc you want around for every event
       void beginJob();
       void endJob();
@@ -150,38 +147,35 @@ namespace emph {
     //.......................................................................
     T0toRPC::T0toRPC(fhicl::ParameterSet const& pset)
       : EDAnalyzer(pset),
-      fFilesAreOpen(false),
-      fTokenJob("none"),
-      fRun(0), fSubRun(0), fPrevSubRun(-1), fEvtNum(0), fPrevEvtNum(-1), 
-      fT0ADCs(nChanT0+2, 0.),
-      fT0TDCs(nChanT0+2, DBL_MAX),
-      fT0TDCsFrAdc(nChanT0+2, DBL_MAX),
-      fRPCTDCs(2*nChanRPC+1, DBL_MAX),
-      fRPCHiLows(2*nChanRPC+1, false),
-      fRPCEChans(2*nChanRPC+1, INT_MAX), // used only for algorithm consistency..
-      fTrigPeakADCs(nChanTrig, 0.),
-      fTrigADCs(nChanTrig, 0.),
-      fMakeT0FullNtuple(true),
-      fMakeRPCFullNtuple(true),
-      fMakeTrigFullNtuple(true),
-      fMakeEventSummaryNTuple(false),
-      fNumT0Hits(0),		     
-      fNumT0HitsFirst(0),		     
-      fNumT0HitsFirstUpDown(0),		     
-      fNumT0Hits2nd(0),		     
-      fNumT0Hits2ndUpDown(0),  	     
-      fT0SegmentHitFirst(-1),
-      fT0SegmentHit2nd(-1),   
-      fT0SumSigUpFirst(0.),
-      fT0SumSigDownFirst(0.),
-      fT0SumSigUp2nd(0.),
-      fT0SumSigDown2nd(0.),
-      fTdcUniqueSegmentBottom(DBL_MAX),
-      fTdcUniqueSegmentTop(DBL_MAX)
+	fFilesAreOpen(false),
+	fTokenJob (pset.get<std::string>("tokenJob", "UnDef")),
+	fRun(0), fSubRun(0), fPrevSubRun(-1), fEvtNum(0), fPrevEvtNum(-1), 
+	fT0ADCs(nChanT0+2, 0.),
+	fT0TDCs(nChanT0+2, DBL_MAX),
+	fT0TDCsFrAdc(nChanT0+2, DBL_MAX),
+	fRPCTDCs(2*nChanRPC+1, DBL_MAX),
+	fRPCHiLows(2*nChanRPC+1, false),
+	fRPCEChans(2*nChanRPC+1, INT_MAX), // used only for algorithm consistency..
+	fTrigPeakADCs(nChanTrig, 0.),
+	fTrigADCs(nChanTrig, 0.),
+	fMakeT0FullNtuple  (pset.get<bool>("makeT0FullNtuple",true)), // keep them for now.. 
+	fMakeRPCFullNtuple (pset.get<bool>("makeRPCFullNtuple",true)),
+        fMakeTrigFullNtuple (pset.get<bool>("makeTrigFullNtuple",true)),
+        fMakeEventSummaryNTuple (pset.get<bool>("makeEventSummaryFullNtuple",false)),
+        fNumT0Hits(0),		     
+        fNumT0HitsFirst(0),		     
+        fNumT0HitsFirstUpDown(0),		     
+        fNumT0Hits2nd(0),		     
+        fNumT0Hits2ndUpDown(0),  	     
+        fT0SegmentHitFirst(-1),
+        fT0SegmentHit2nd(-1),   
+        fT0SumSigUpFirst(0.),
+        fT0SumSigDownFirst(0.),
+        fT0SumSigUp2nd(0.),
+        fT0SumSigDown2nd(0.),
+        fTdcUniqueSegmentBottom(DBL_MAX),
+        fTdcUniqueSegmentTop(DBL_MAX)
     {
-
-      this->reconfigure(pset);
-
     }
     
     //......................................................................
@@ -197,17 +191,6 @@ namespace emph {
       //======================================================================
       // Clean up any memory allocated by your module
       //======================================================================
-    }
-
-    //......................................................................
-    void T0toRPC::reconfigure(const fhicl::ParameterSet& pset)
-    {
-      fTokenJob = pset.get<std::string>("tokenJob", "UnDef");
-      fMakeT0FullNtuple  = pset.get<bool>("makeT0FullNtuple",true); // keep them for now.. 
-      fMakeRPCFullNtuple = pset.get<bool>("makeRPCFullNtuple",true);
-      fMakeTrigFullNtuple = pset.get<bool>("makeTrigFullNtuple",true);
-      fMakeEventSummaryNTuple = pset.get<bool>("makeEventSummaryFullNtuple",false);
-      
     }
 
     //......................................................................

--- a/TOF/TrigToT0Prod_module.cc
+++ b/TOF/TrigToT0Prod_module.cc
@@ -54,9 +54,6 @@ namespace emph {
      // Optional, read/write access to event
       void produce(art::Event& evt) override;
 
-      // Optional if you want to be able to configure from event display, for example
-      void reconfigure(const fhicl::ParameterSet& pset);
-
       // Optional use if you have histograms, ntuples, etc you want around for every event
       void beginJob();
       void endJob();
@@ -144,19 +141,19 @@ namespace emph {
     //.......................................................................
     TrigToT0Prod::TrigToT0Prod(fhicl::ParameterSet const& pset)
       : EDProducer(pset),
-      fFilesAreOpen(false),
-      fTokenJob("none"),
-      fRun(0), fSubRun(0), fEvtNum(0), 
-      fT0ADCs(nChanT0+2, 0.),
-      fT0TDCs(nChanT0+2, DBL_MAX),
-      fT0TDCsFrAdc(nChanT0+2, DBL_MAX),
-      fTrigPeakADCs(nChanTrig, 0.),
-      fTrigADCs(nChanTrig, 0.),
-      fMakeT0FullNtuple(true),
-      fMakeTrigFullNtuple(true),
-      fMakeEventSummaryNTuple(true),
-      fNumT0Hits(0),		     
-      fNumT0HitsFirst(0),		     
+	fFilesAreOpen(false),
+	fTokenJob (pset.get<std::string>("tokenJob", "UnDef")),
+	fRun(0), fSubRun(0), fEvtNum(0), 
+	fT0ADCs(nChanT0+2, 0.),
+	fT0TDCs(nChanT0+2, DBL_MAX),
+	fT0TDCsFrAdc(nChanT0+2, DBL_MAX),
+	fTrigPeakADCs(nChanTrig, 0.),
+	fTrigADCs(nChanTrig, 0.),
+	fMakeT0FullNtuple  (pset.get<bool>("makeT0FullNtuple",true)), // keep them for now.. 
+	fMakeTrigFullNtuple (pset.get<bool>("makeTrigFullNtuple",true)),
+	fMakeEventSummaryNTuple (pset.get<bool>("makeEventSummaryFullNtuple",false)),
+	fNumT0Hits(0),		     
+	fNumT0HitsFirst(0),		     
       fNumT0HitsFirstUpDown(0),		     
       fNumT0Hits2nd(0),		     
       fNumT0Hits2ndUpDown(0),  	     
@@ -170,7 +167,6 @@ namespace emph {
       fTdcUniqueSegmentTop(DBL_MAX)
     {
 
-      this->reconfigure(pset);
       produces< rb::TrigToT0 >();
 
     }
@@ -187,16 +183,6 @@ namespace emph {
       //======================================================================
       // Clean up any memory allocated by your module
       //======================================================================
-    }
-
-    //......................................................................
-    void TrigToT0Prod::reconfigure(const fhicl::ParameterSet& pset)
-    {
-      fTokenJob = pset.get<std::string>("tokenJob", "UnDef");
-      fMakeT0FullNtuple  = pset.get<bool>("makeT0FullNtuple",true); // keep them for now.. 
-      fMakeTrigFullNtuple = pset.get<bool>("makeTrigFullNtuple",true);
-      fMakeEventSummaryNTuple = pset.get<bool>("makeEventSummaryFullNtuple",false);
-      
     }
 
     //......................................................................


### PR DESCRIPTION
…s creeping into code through people copying old modules. There were a few places where reconfigure was doing some heavier lifting than just grabbing the pset. For the simpler cases I just moved these lines into the constructor. For a few I created a new function that basically does the same as reconfigure did.