### PR TITLE
Bugfix/lackey32 caf filename

### DIFF
--- a/CAFMaker/CAFMaker_module.cc
+++ b/CAFMaker/CAFMaker_module.cc
@@ -135,6 +135,7 @@ namespace caf {
       char *temp = new char[fb.fileName().size() + 1];
       std::strcpy(temp, fb.fileName().c_str());
       fCAFFilename = basename(temp);
+      // Expects filename to end with .XXXX e.g., '.root'
       const size_t dotpos = fCAFFilename.find_last_of('.',fCAFFilename.length()-6);
       assert(dotpos != std::string::npos);  // Must have a dot, surely?
       fCAFFilename.resize(dotpos);

--- a/CAFMaker/CAFMaker_module.cc
+++ b/CAFMaker/CAFMaker_module.cc
@@ -135,7 +135,7 @@ namespace caf {
       char *temp = new char[fb.fileName().size() + 1];
       std::strcpy(temp, fb.fileName().c_str());
       fCAFFilename = basename(temp);
-      const size_t dotpos = fCAFFilename.find('.');
+      const size_t dotpos = fCAFFilename.find_last_of('.',fCAFFilename.length()-6);
       assert(dotpos != std::string::npos);  // Must have a dot, surely?
       fCAFFilename.resize(dotpos);
       fCAFFilename += fParams.FileExtension();


### PR DESCRIPTION
Finds second to last dot in filename so we keep the entire beginning but drop `.artdaq.root` (or whatever else the end may be) in favor of .caf.root.
This could cause some confusion if people run over files that don't end with `.<type>.root`.

The alternative option is the first commit, which just replaces the find line with
`const size_t dotpos = fCAFFilename.find_last_of('.',fCAFFilename.length()-6);`
but that assumes the end of the file will always be the same number of characters as .root. I would hope the name always ends in .root, but are we positive it will?

I'm honestly not sure which one is safer / will cause less confusion. I think I'm leaning towards the single line version right now, but that might change in 5 minutes.