### PR TITLE
Fix reload geometry crash to enable running over multiple files in one job.

### DIFF
--- a/Geometry/service/GeometryService.h
+++ b/Geometry/service/GeometryService.h
@@ -36,7 +36,8 @@ namespace emph
 
     private:
       std::unique_ptr<emph::geo::Geometry> fGeometry;
-
+      unsigned int fRunNumber;
+      std::string  fLoadedGeoFile;
     };
     
   }

--- a/Geometry/service/Geometry_service.cc
+++ b/Geometry/service/Geometry_service.cc
@@ -20,6 +20,8 @@ namespace emph
     //------------------------------------------------------------
     GeometryService::GeometryService(const fhicl::ParameterSet& pset,
 					 art::ActivityRegistry & reg)
+      : fRunNumber(0),
+	fLoadedGeoFile("none")
     {
       TGeoManager::LockDefaultUnits(0);
       TGeoManager::SetDefaultUnits(TGeoManager::EDefaultUnits::kRootUnits);
@@ -40,12 +42,26 @@ namespace emph
     // If we have run-dependent geometry, do something here to reload
     // the geometry if necessary
     //----------------------------------------------------------
-    void GeometryService::preBeginRun(const art::Run& )
+    void GeometryService::preBeginRun(const art::Run& run)
     {
       std::cout << "GeometryService::preBeginRun" << std::endl;
+      // Check if geo has already been loaded for this run
+      if(run.run() == fRunNumber) return;
+      fRunNumber = run.run();
+
       art::ServiceHandle<runhist::RunHistoryService> rhs;
+
+      const std::string newGeoFile = rhs->RunHist()->GeoFile();
       
-      fGeometry.reset(new emph::geo::Geometry(rhs->RunHist()->GeoFile() ) );
+      // Only load geometry if it has changed
+      if (newGeoFile == fLoadedGeoFile){
+	std::cout << "Geometry for run " << fRunNumber
+		  << " unchanged from previous run." << std::endl;
+	return;
+      }
+      
+      fGeometry.reset(new emph::geo::Geometry(newGeoFile) );
+      fLoadedGeoFile = newGeoFile;
       
     }
     

--- a/setup/setup_emphatic.sh
+++ b/setup/setup_emphatic.sh
@@ -106,3 +106,4 @@ export LIBGL_ALWAYS_INDIRECT=1
 # Additional setup
 setup ninja
 setup art_cpp_db_interfaces v1_4_0
+setup gdb v12_1


### PR DESCRIPTION
GeometryService now first checks the run number; if it's the same as the previous file, simply return. If it's different, check if the geometry filename has changed; if it's the same, return.

I suspect this will still crash when running over files from different phases, but there's not much of a use case for that anyways.