### PR TITLE
Hot fix for the bug in PR 149

### DIFF
--- a/ConstBase/Geometry/phase1c-BeTarget.gdml
+++ b/ConstBase/Geometry/phase1c-BeTarget.gdml
@@ -114,97 +114,97 @@
 	 <quantity name="ssdStationsingleHeight" value="300" unit="mm" />
 
 		<position name="ssdStation0_pos" x="0" y="0" z="ssdStation0_shift+ssdD0_thick-0.5*mount_thick"/>
-						<position name="ssdsensor_0_0_0_pos" x="0" y="0" z="(0+0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0+0-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_0_0_0_pos" x="0" y="0" z="(0+0)*ssdD0_thick+(0-0.5)*mount_thick+(0+0-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_0_0_0_rot" x="180.0*0" y="0" z="0" unit="deg"/>
-						<position name="ssdsensor_0_1_0_pos" x="0" y="0" z="(1+0-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1+0-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_0_1_0_pos" x="0" y="0" z="(1+0)*ssdD0_thick+(1-0.5)*mount_thick+(1+0-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_0_1_0_rot" x="180.0*1" y="0" z="90" unit="deg"/>
+						<position name="ssdsensor_0_0_0_pos" x="0" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_0_0_0_pos" x="0" y="0" z="(0)*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_0_0_0_rot" x="180.0*0" y="0" z="0" unit="deg"/>
+						<position name="ssdsensor_0_1_0_pos" x="0" y="0" z="(0-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_0_1_0_pos" x="0" y="0" z="(0)*ssdD0_thick+(1-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_0_1_0_rot" x="180.0*1" y="0" z="90" unit="deg"/>
 		<position name="ssdStation1_pos" x="0" y="0" z="ssdStation1_shift+ssdD0_thick-0.5*mount_thick"/>
-						<position name="ssdsensor_1_0_0_pos" x="0" y="0" z="(0+0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0+0-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_1_0_0_pos" x="0" y="0" z="(0+0)*ssdD0_thick+(0-0.5)*mount_thick+(0+0-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_1_0_0_rot" x="180.0*0" y="0" z="0" unit="deg"/>
-						<position name="ssdsensor_1_1_0_pos" x="0" y="0" z="(1+0-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1+0-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_1_1_0_pos" x="0" y="0" z="(1+0)*ssdD0_thick+(1-0.5)*mount_thick+(1+0-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_1_1_0_rot" x="180.0*1" y="0" z="90" unit="deg"/>
+						<position name="ssdsensor_1_0_0_pos" x="0" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_1_0_0_pos" x="0" y="0" z="(0)*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_1_0_0_rot" x="180.0*0" y="0" z="0" unit="deg"/>
+						<position name="ssdsensor_1_1_0_pos" x="0" y="0" z="(0-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_1_1_0_pos" x="0" y="0" z="(0)*ssdD0_thick+(1-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_1_1_0_rot" x="180.0*1" y="0" z="90" unit="deg"/>
 		<position name="ssdStation2_pos" x="0" y="0" z="ssdStation2_shift+ssdD0_thick-0.5*mount_thick"/>
-						<position name="ssdsensor_2_0_0_pos" x="0" y="0" z="(0+0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0+0-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_2_0_0_pos" x="0" y="0" z="(0+0)*ssdD0_thick+(0-0.5)*mount_thick+(0+0-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_2_0_0_rot" x="180.0*0" y="0" z="315" unit="deg"/>
-						<position name="ssdsensor_2_1_0_pos" x="0" y="0" z="(1+0-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1+0-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_2_1_0_pos" x="0" y="0" z="(1+0)*ssdD0_thick+(1-0.5)*mount_thick+(1+0-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_2_1_0_rot" x="180.0*0" y="0" z="0" unit="deg"/>
-                   <position name="ssdsensor_2_2_0_pos" x="0" y="0" z="(0+0.5)*ssdD0_thick+ssd_bkpln_thick+0.5*mount_thick"/>
-						<position name="ssd_bkpln_2_2_0_pos" x="0" y="0" z="(0+0.5)*ssd_bkpln_thick+0.5*mount_thick"/>
-					 	<rotation name="ssdsensor_2_2_0_rot" x="180.0*1" y="0" z="90" unit="deg"/>
+						<position name="ssdsensor_2_0_0_pos" x="0" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_2_0_0_pos" x="0" y="0" z="(0)*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_2_0_0_rot" x="180.0*0" y="0" z="315" unit="deg"/>
+						<position name="ssdsensor_2_1_0_pos" x="0" y="0" z="(0-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_2_1_0_pos" x="0" y="0" z="(0)*ssdD0_thick+(1-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_2_1_0_rot" x="180.0*0" y="0" z="0" unit="deg"/>
+						<position name="ssdsensor_2_2_0_pos" x="0" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_2_2_0_pos" x="0" y="0" z="(0)*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_2_2_0_rot" x="180.0*1" y="0" z="90" unit="deg"/>
 		<position name="ssdStation3_pos" x="0" y="0" z="ssdStation3_shift+ssdD0_thick-0.5*mount_thick"/>
-						<position name="ssdsensor_3_0_0_pos" x="0" y="0" z="(0+0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0+0-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_3_0_0_pos" x="0" y="0" z="(0+0)*ssdD0_thick+(0-0.5)*mount_thick+(0+0-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_3_0_0_rot" x="180.0*0" y="0" z="315" unit="deg"/>
-						<position name="ssdsensor_3_1_0_pos" x="0" y="0" z="(1+0-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1+0-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_3_1_0_pos" x="0" y="0" z="(1+0)*ssdD0_thick+(1-0.5)*mount_thick+(1+0-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_3_1_0_rot" x="180.0*0" y="0" z="0" unit="deg"/>
-                   <position name="ssdsensor_3_2_0_pos" x="0" y="0" z="(0+0.5)*ssdD0_thick+ssd_bkpln_thick+0.5*mount_thick"/>
-						<position name="ssd_bkpln_3_2_0_pos" x="0" y="0" z="(0+0.5)*ssd_bkpln_thick+0.5*mount_thick"/>
-					 	<rotation name="ssdsensor_3_2_0_rot" x="180.0*1" y="0" z="90" unit="deg"/>
+						<position name="ssdsensor_3_0_0_pos" x="0" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_3_0_0_pos" x="0" y="0" z="(0)*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_3_0_0_rot" x="180.0*0" y="0" z="315" unit="deg"/>
+						<position name="ssdsensor_3_1_0_pos" x="0" y="0" z="(0-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_3_1_0_pos" x="0" y="0" z="(0)*ssdD0_thick+(1-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_3_1_0_rot" x="180.0*0" y="0" z="0" unit="deg"/>
+						<position name="ssdsensor_3_2_0_pos" x="0" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_3_2_0_pos" x="0" y="0" z="(0)*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_3_2_0_rot" x="180.0*1" y="0" z="90" unit="deg"/>
 		<position name="ssdStation4_pos" x="0" y="0" z="ssdStation4_shift+ssdD0_thick-0.5*mount_thick"/>
-						<position name="ssdsensor_4_0_0_pos" x="0" y="0" z="(0+0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0+0-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_4_0_0_pos" x="0" y="0" z="(0+0)*ssdD0_thick+(0-0.5)*mount_thick+(0+0-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_4_0_0_rot" x="180.0*0" y="0" z="0" unit="deg"/>
-						<position name="ssdsensor_4_1_0_pos" x="0" y="0" z="(1+0-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1+0-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_4_1_0_pos" x="0" y="0" z="(1+0)*ssdD0_thick+(1-0.5)*mount_thick+(1+0-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_4_1_0_rot" x="180.0*1" y="0" z="90" unit="deg"/>
+						<position name="ssdsensor_4_0_0_pos" x="0" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_4_0_0_pos" x="0" y="0" z="(0)*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_4_0_0_rot" x="180.0*0" y="0" z="0" unit="deg"/>
+						<position name="ssdsensor_4_1_0_pos" x="0" y="0" z="(0-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_4_1_0_pos" x="0" y="0" z="(0)*ssdD0_thick+(1-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_4_1_0_rot" x="180.0*1" y="0" z="90" unit="deg"/>
 		<position name="ssdStation5_pos" x="0" y="0" z="ssdStation5_shift+ssdD0_thick-0.5*mount_thick"/>
-						<position name="ssdsensor_5_0_0_pos" x="-18.23" y="0" z="(0+0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0+0-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_5_0_0_pos" x="-18.23" y="0" z="(0+0)*ssdD0_thick+(0-0.5)*mount_thick+(0+0-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_5_0_0_rot" x="180.0*0" y="0" z="270" unit="deg"/>
-						<position name="ssdsensor_5_0_1_pos" x="18.23" y="0" z="(0+1-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0+1-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_5_0_1_pos" x="18.23" y="0" z="(0+1)*ssdD0_thick+(0-0.5)*mount_thick+(0+1-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_5_0_1_rot" x="180.0*0" y="0" z="90" unit="deg"/>
-						<position name="ssdsensor_5_1_0_pos" x="0" y="-18.23" z="(1+0-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1+0-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_5_1_0_pos" x="0" y="-18.23" z="(1+0)*ssdD0_thick+(1-0.5)*mount_thick+(1+0-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_5_1_0_rot" x="180.0*1" y="0" z="0" unit="deg"/>
-						<position name="ssdsensor_5_1_1_pos" x="0" y="18.23" z="(1+1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1+1-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_5_1_1_pos" x="0" y="18.23" z="(1+1)*ssdD0_thick+(1-0.5)*mount_thick+(1+1-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_5_1_1_rot" x="180.0*1" y="0" z="180" unit="deg"/>
-                   <position name="ssdsensor_5_2_0_pos" x="12.92" y="-12.92" z="(0+0.5)*ssdD0_thick+ssd_bkpln_thick+0.5*mount_thick"/>
-						<position name="ssd_bkpln_5_2_0_pos" x="12.92" y="-12.92" z="(0+0.5)*ssd_bkpln_thick+0.5*mount_thick"/>
-					 	<rotation name="ssdsensor_5_2_0_rot" x="180.0*1" y="0" z="45" unit="deg"/>
-                   <position name="ssdsensor_5_2_1_pos" x="-12.92" y="12.92" z="(1+0.5)*ssdD0_thick+ssd_bkpln_thick+0.5*mount_thick"/>
-						<position name="ssd_bkpln_5_2_1_pos" x="-12.92" y="12.92" z="(1+0.5)*ssd_bkpln_thick+0.5*mount_thick"/>
-					 	<rotation name="ssdsensor_5_2_1_rot" x="180.0*1" y="0" z="225" unit="deg"/>
+						<position name="ssdsensor_5_0_0_pos" x="-18.23" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_5_0_0_pos" x="-18.23" y="0" z="(0)*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_5_0_0_rot" x="180.0*0" y="0" z="270" unit="deg"/>
+						<position name="ssdsensor_5_0_1_pos" x="18.23" y="0" z="(1-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(1-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_5_0_1_pos" x="18.23" y="0" z="(1)*ssdD0_thick+(0-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_5_0_1_rot" x="180.0*0" y="0" z="90" unit="deg"/>
+						<position name="ssdsensor_5_1_0_pos" x="0" y="-18.23" z="(0-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_5_1_0_pos" x="0" y="-18.23" z="(0)*ssdD0_thick+(1-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_5_1_0_rot" x="180.0*1" y="0" z="0" unit="deg"/>
+						<position name="ssdsensor_5_1_1_pos" x="0" y="18.23" z="(1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_5_1_1_pos" x="0" y="18.23" z="(1)*ssdD0_thick+(1-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_5_1_1_rot" x="180.0*1" y="0" z="180" unit="deg"/>
+						<position name="ssdsensor_5_2_0_pos" x="12.92" y="-12.92" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_5_2_0_pos" x="12.92" y="-12.92" z="(0)*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_5_2_0_rot" x="180.0*1" y="0" z="45" unit="deg"/>
+						<position name="ssdsensor_5_2_1_pos" x="-12.92" y="12.92" z="(1-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(1-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_5_2_1_pos" x="-12.92" y="12.92" z="(1)*ssdD0_thick+(0-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_5_2_1_rot" x="180.0*1" y="0" z="225" unit="deg"/>
 		<position name="ssdStation6_pos" x="0" y="0" z="ssdStation6_shift+ssdD0_thick-0.5*mount_thick"/>
-						<position name="ssdsensor_6_0_0_pos" x="-18.23" y="0" z="(0+0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0+0-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_6_0_0_pos" x="-18.23" y="0" z="(0+0)*ssdD0_thick+(0-0.5)*mount_thick+(0+0-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_6_0_0_rot" x="180.0*0" y="0" z="270" unit="deg"/>
-						<position name="ssdsensor_6_0_1_pos" x="18.23" y="0" z="(0+1-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0+1-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_6_0_1_pos" x="18.23" y="0" z="(0+1)*ssdD0_thick+(0-0.5)*mount_thick+(0+1-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_6_0_1_rot" x="180.0*0" y="0" z="90" unit="deg"/>
-						<position name="ssdsensor_6_1_0_pos" x="0" y="-18.23" z="(1+0-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1+0-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_6_1_0_pos" x="0" y="-18.23" z="(1+0)*ssdD0_thick+(1-0.5)*mount_thick+(1+0-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_6_1_0_rot" x="180.0*1" y="0" z="0" unit="deg"/>
-						<position name="ssdsensor_6_1_1_pos" x="0" y="18.23" z="(1+1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1+1-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_6_1_1_pos" x="0" y="18.23" z="(1+1)*ssdD0_thick+(1-0.5)*mount_thick+(1+1-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_6_1_1_rot" x="180.0*1" y="0" z="180" unit="deg"/>
-                   <position name="ssdsensor_6_2_0_pos" x="12.92" y="-12.92" z="(0+0.5)*ssdD0_thick+ssd_bkpln_thick+0.5*mount_thick"/>
-						<position name="ssd_bkpln_6_2_0_pos" x="12.92" y="-12.92" z="(0+0.5)*ssd_bkpln_thick+0.5*mount_thick"/>
-					 	<rotation name="ssdsensor_6_2_0_rot" x="180.0*1" y="0" z="45" unit="deg"/>
-                   <position name="ssdsensor_6_2_1_pos" x="-12.92" y="12.92" z="(1+0.5)*ssdD0_thick+ssd_bkpln_thick+0.5*mount_thick"/>
-						<position name="ssd_bkpln_6_2_1_pos" x="-12.92" y="12.92" z="(1+0.5)*ssd_bkpln_thick+0.5*mount_thick"/>
-					 	<rotation name="ssdsensor_6_2_1_rot" x="180.0*1" y="0" z="225" unit="deg"/>
+						<position name="ssdsensor_6_0_0_pos" x="-18.23" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_6_0_0_pos" x="-18.23" y="0" z="(0)*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_6_0_0_rot" x="180.0*0" y="0" z="270" unit="deg"/>
+						<position name="ssdsensor_6_0_1_pos" x="18.23" y="0" z="(1-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(1-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_6_0_1_pos" x="18.23" y="0" z="(1)*ssdD0_thick+(0-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_6_0_1_rot" x="180.0*0" y="0" z="90" unit="deg"/>
+						<position name="ssdsensor_6_1_0_pos" x="0" y="-18.23" z="(0-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_6_1_0_pos" x="0" y="-18.23" z="(0)*ssdD0_thick+(1-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_6_1_0_rot" x="180.0*1" y="0" z="0" unit="deg"/>
+						<position name="ssdsensor_6_1_1_pos" x="0" y="18.23" z="(1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_6_1_1_pos" x="0" y="18.23" z="(1)*ssdD0_thick+(1-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_6_1_1_rot" x="180.0*1" y="0" z="180" unit="deg"/>
+						<position name="ssdsensor_6_2_0_pos" x="12.92" y="-12.92" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_6_2_0_pos" x="12.92" y="-12.92" z="(0)*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_6_2_0_rot" x="180.0*1" y="0" z="45" unit="deg"/>
+						<position name="ssdsensor_6_2_1_pos" x="-12.92" y="12.92" z="(1-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(1-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_6_2_1_pos" x="-12.92" y="12.92" z="(1)*ssdD0_thick+(0-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_6_2_1_rot" x="180.0*1" y="0" z="225" unit="deg"/>
 		<position name="ssdStation7_pos" x="0" y="0" z="ssdStation7_shift+ssdD0_thick-0.5*mount_thick"/>
-						<position name="ssdsensor_7_0_0_pos" x="-18.23" y="0" z="(0+0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0+0-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_7_0_0_pos" x="-18.23" y="0" z="(0+0)*ssdD0_thick+(0-0.5)*mount_thick+(0+0-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_7_0_0_rot" x="180.0*0" y="0" z="270" unit="deg"/>
-						<position name="ssdsensor_7_0_1_pos" x="18.23" y="0" z="(0+1-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0+1-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_7_0_1_pos" x="18.23" y="0" z="(0+1)*ssdD0_thick+(0-0.5)*mount_thick+(0+1-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_7_0_1_rot" x="180.0*0" y="0" z="90" unit="deg"/>
-						<position name="ssdsensor_7_1_0_pos" x="0" y="-18.23" z="(1+0-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1+0-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_7_1_0_pos" x="0" y="-18.23" z="(1+0)*ssdD0_thick+(1-0.5)*mount_thick+(1+0-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_7_1_0_rot" x="180.0*1" y="0" z="0" unit="deg"/>
-						<position name="ssdsensor_7_1_1_pos" x="0" y="19.23" z="(1+1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1+1-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_7_1_1_pos" x="0" y="19.23" z="(1+1)*ssdD0_thick+(1-0.5)*mount_thick+(1+1-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_7_1_1_rot" x="180.0*1" y="0" z="180" unit="deg"/>
+						<position name="ssdsensor_7_0_0_pos" x="-18.23" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_7_0_0_pos" x="-18.23" y="0" z="(0)*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_7_0_0_rot" x="180.0*0" y="0" z="270" unit="deg"/>
+						<position name="ssdsensor_7_0_1_pos" x="18.23" y="0" z="(1-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(1-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_7_0_1_pos" x="18.23" y="0" z="(1)*ssdD0_thick+(0-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_7_0_1_rot" x="180.0*0" y="0" z="90" unit="deg"/>
+						<position name="ssdsensor_7_1_0_pos" x="0" y="-18.23" z="(0-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_7_1_0_pos" x="0" y="-18.23" z="(0)*ssdD0_thick+(1-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_7_1_0_rot" x="180.0*1" y="0" z="0" unit="deg"/>
+						<position name="ssdsensor_7_1_1_pos" x="0" y="19.23" z="(1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_7_1_1_pos" x="0" y="19.23" z="(1)*ssdD0_thick+(1-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_7_1_1_rot" x="180.0*1" y="0" z="180" unit="deg"/>
 				<position name="ssdmount_local_0_0_pos" x="0" y="0" z="0"/>
 				<position name="ssdmount_0_0_pos" x="0" y="0" z="0+0.5*mount_thick"/>
 				<rotation name="ssdmount_0_0_rot" x="-0.44" y="-2.02" unit="deg"/>
@@ -242,8 +242,8 @@
 				<position name="ssdmount_7_0_pos" x="0" y="0" z="0+0.5*mount_thick"/>
 				<rotation name="ssdmount_7_0_rot" x="0.36" y="0.31" unit="deg"/>
 
-	 <position name="ssd_USMylarWindow_pos" x="0" y="0" z="Mylar_shift"/>
-	 <position name="ssd_DSMylarWindow_pos" x="0" y="0" z="-1.*Mylar_shift"/>
+	 <position name="ssd_USMylarWindow_pos" x="0" y="0" z="-1*Mylar_shift"/>
+	 <position name="ssd_DSMylarWindow_pos" x="0" y="0" z="Mylar_shift"/>
 
 
 		<position name="ssd_mount_u1_pos" x="70" y="0" z="0"/>
@@ -254,8 +254,8 @@
 		<position name="ssd_mount_u4_pos" x="80.1" y="-80.4"/>
 		<rotation name="ssd_mount_u4_rot" y="-90" z="135" unit="deg"/>
 
-	 <position name="ssd_mount_out_pos1" z="0.5*mount_thick+0.5*ssdD0_thick+0.5*ssd_bkpln_thick" unit="mm" />
-	 <position name="ssd_mount_out_pos2" z="-0.5*mount_thick-0.5*ssdD0_thick-0.5*ssd_bkpln_thick" unit="mm" />
+	 <position name="ssd_mount_out_pos1" z="0.5*mount_thick" unit="mm" />
+	 <position name="ssd_mount_out_pos2" z="-0.5*mount_thick" unit="mm" />
 
 	 <quantity name="ssdStationrotateLength" value="50" unit="mm" />
 	 <quantity name="ssdStationrotateWidth" value="300" unit="mm" />
@@ -2160,7 +2160,7 @@ values="202.14067278287462 12.054573032169143
 		<second ref="ssd_mount_box2"/>
 	 </subtraction>
 
-	 <box name="ssd_mount_out_box" x="1.2*mount_width" y="1.2*mount_width" z="ssdD0_thick+ssd_bkpln_thick" />
+	 <box name="ssd_mount_out_box" x="1.2*mount_width" y="1.2*mount_width" z="2*ssdD0_thick+2*ssd_bkpln_thick" />
 	 <union name="ssd_mount_enclosure_u1">
 	   <first ref="ssd_mount_box"/>
 		<second ref="ssd_mount_out_box"/>

--- a/ConstBase/Geometry/phase1c-CH2.gdml
+++ b/ConstBase/Geometry/phase1c-CH2.gdml
@@ -114,97 +114,97 @@
 	 <quantity name="ssdStationsingleHeight" value="300" unit="mm" />
 
 		<position name="ssdStation0_pos" x="0" y="0" z="ssdStation0_shift+ssdD0_thick-0.5*mount_thick"/>
-						<position name="ssdsensor_0_0_0_pos" x="0" y="0" z="(0+0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0+0-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_0_0_0_pos" x="0" y="0" z="(0+0)*ssdD0_thick+(0-0.5)*mount_thick+(0+0-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_0_0_0_rot" x="180.0*0" y="0" z="0" unit="deg"/>
-						<position name="ssdsensor_0_1_0_pos" x="0" y="0" z="(1+0-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1+0-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_0_1_0_pos" x="0" y="0" z="(1+0)*ssdD0_thick+(1-0.5)*mount_thick+(1+0-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_0_1_0_rot" x="180.0*1" y="0" z="90" unit="deg"/>
+						<position name="ssdsensor_0_0_0_pos" x="0" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_0_0_0_pos" x="0" y="0" z="(0)*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_0_0_0_rot" x="180.0*0" y="0" z="0" unit="deg"/>
+						<position name="ssdsensor_0_1_0_pos" x="0" y="0" z="(0-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_0_1_0_pos" x="0" y="0" z="(0)*ssdD0_thick+(1-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_0_1_0_rot" x="180.0*1" y="0" z="90" unit="deg"/>
 		<position name="ssdStation1_pos" x="0" y="0" z="ssdStation1_shift+ssdD0_thick-0.5*mount_thick"/>
-						<position name="ssdsensor_1_0_0_pos" x="0" y="0" z="(0+0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0+0-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_1_0_0_pos" x="0" y="0" z="(0+0)*ssdD0_thick+(0-0.5)*mount_thick+(0+0-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_1_0_0_rot" x="180.0*0" y="0" z="0" unit="deg"/>
-						<position name="ssdsensor_1_1_0_pos" x="0" y="0" z="(1+0-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1+0-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_1_1_0_pos" x="0" y="0" z="(1+0)*ssdD0_thick+(1-0.5)*mount_thick+(1+0-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_1_1_0_rot" x="180.0*1" y="0" z="90" unit="deg"/>
+						<position name="ssdsensor_1_0_0_pos" x="0" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_1_0_0_pos" x="0" y="0" z="(0)*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_1_0_0_rot" x="180.0*0" y="0" z="0" unit="deg"/>
+						<position name="ssdsensor_1_1_0_pos" x="0" y="0" z="(0-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_1_1_0_pos" x="0" y="0" z="(0)*ssdD0_thick+(1-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_1_1_0_rot" x="180.0*1" y="0" z="90" unit="deg"/>
 		<position name="ssdStation2_pos" x="0" y="0" z="ssdStation2_shift+ssdD0_thick-0.5*mount_thick"/>
-						<position name="ssdsensor_2_0_0_pos" x="0" y="0" z="(0+0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0+0-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_2_0_0_pos" x="0" y="0" z="(0+0)*ssdD0_thick+(0-0.5)*mount_thick+(0+0-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_2_0_0_rot" x="180.0*0" y="0" z="315" unit="deg"/>
-						<position name="ssdsensor_2_1_0_pos" x="0" y="0" z="(1+0-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1+0-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_2_1_0_pos" x="0" y="0" z="(1+0)*ssdD0_thick+(1-0.5)*mount_thick+(1+0-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_2_1_0_rot" x="180.0*0" y="0" z="0" unit="deg"/>
-                   <position name="ssdsensor_2_2_0_pos" x="0" y="0" z="(0+0.5)*ssdD0_thick+ssd_bkpln_thick+0.5*mount_thick"/>
-						<position name="ssd_bkpln_2_2_0_pos" x="0" y="0" z="(0+0.5)*ssd_bkpln_thick+0.5*mount_thick"/>
-					 	<rotation name="ssdsensor_2_2_0_rot" x="180.0*1" y="0" z="90" unit="deg"/>
+						<position name="ssdsensor_2_0_0_pos" x="0" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_2_0_0_pos" x="0" y="0" z="(0)*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_2_0_0_rot" x="180.0*0" y="0" z="315" unit="deg"/>
+						<position name="ssdsensor_2_1_0_pos" x="0" y="0" z="(0-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_2_1_0_pos" x="0" y="0" z="(0)*ssdD0_thick+(1-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_2_1_0_rot" x="180.0*0" y="0" z="0" unit="deg"/>
+						<position name="ssdsensor_2_2_0_pos" x="0" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_2_2_0_pos" x="0" y="0" z="(0)*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_2_2_0_rot" x="180.0*1" y="0" z="90" unit="deg"/>
 		<position name="ssdStation3_pos" x="0" y="0" z="ssdStation3_shift+ssdD0_thick-0.5*mount_thick"/>
-						<position name="ssdsensor_3_0_0_pos" x="0" y="0" z="(0+0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0+0-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_3_0_0_pos" x="0" y="0" z="(0+0)*ssdD0_thick+(0-0.5)*mount_thick+(0+0-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_3_0_0_rot" x="180.0*0" y="0" z="315" unit="deg"/>
-						<position name="ssdsensor_3_1_0_pos" x="0" y="0" z="(1+0-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1+0-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_3_1_0_pos" x="0" y="0" z="(1+0)*ssdD0_thick+(1-0.5)*mount_thick+(1+0-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_3_1_0_rot" x="180.0*0" y="0" z="0" unit="deg"/>
-                   <position name="ssdsensor_3_2_0_pos" x="0" y="0" z="(0+0.5)*ssdD0_thick+ssd_bkpln_thick+0.5*mount_thick"/>
-						<position name="ssd_bkpln_3_2_0_pos" x="0" y="0" z="(0+0.5)*ssd_bkpln_thick+0.5*mount_thick"/>
-					 	<rotation name="ssdsensor_3_2_0_rot" x="180.0*1" y="0" z="90" unit="deg"/>
+						<position name="ssdsensor_3_0_0_pos" x="0" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_3_0_0_pos" x="0" y="0" z="(0)*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_3_0_0_rot" x="180.0*0" y="0" z="315" unit="deg"/>
+						<position name="ssdsensor_3_1_0_pos" x="0" y="0" z="(0-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_3_1_0_pos" x="0" y="0" z="(0)*ssdD0_thick+(1-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_3_1_0_rot" x="180.0*0" y="0" z="0" unit="deg"/>
+						<position name="ssdsensor_3_2_0_pos" x="0" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_3_2_0_pos" x="0" y="0" z="(0)*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_3_2_0_rot" x="180.0*1" y="0" z="90" unit="deg"/>
 		<position name="ssdStation4_pos" x="0" y="0" z="ssdStation4_shift+ssdD0_thick-0.5*mount_thick"/>
-						<position name="ssdsensor_4_0_0_pos" x="0" y="0" z="(0+0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0+0-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_4_0_0_pos" x="0" y="0" z="(0+0)*ssdD0_thick+(0-0.5)*mount_thick+(0+0-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_4_0_0_rot" x="180.0*0" y="0" z="0" unit="deg"/>
-						<position name="ssdsensor_4_1_0_pos" x="0" y="0" z="(1+0-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1+0-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_4_1_0_pos" x="0" y="0" z="(1+0)*ssdD0_thick+(1-0.5)*mount_thick+(1+0-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_4_1_0_rot" x="180.0*1" y="0" z="90" unit="deg"/>
+						<position name="ssdsensor_4_0_0_pos" x="0" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_4_0_0_pos" x="0" y="0" z="(0)*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_4_0_0_rot" x="180.0*0" y="0" z="0" unit="deg"/>
+						<position name="ssdsensor_4_1_0_pos" x="0" y="0" z="(0-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_4_1_0_pos" x="0" y="0" z="(0)*ssdD0_thick+(1-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_4_1_0_rot" x="180.0*1" y="0" z="90" unit="deg"/>
 		<position name="ssdStation5_pos" x="0" y="0" z="ssdStation5_shift+ssdD0_thick-0.5*mount_thick"/>
-						<position name="ssdsensor_5_0_0_pos" x="-18.23" y="0" z="(0+0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0+0-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_5_0_0_pos" x="-18.23" y="0" z="(0+0)*ssdD0_thick+(0-0.5)*mount_thick+(0+0-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_5_0_0_rot" x="180.0*0" y="0" z="270" unit="deg"/>
-						<position name="ssdsensor_5_0_1_pos" x="18.23" y="0" z="(0+1-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0+1-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_5_0_1_pos" x="18.23" y="0" z="(0+1)*ssdD0_thick+(0-0.5)*mount_thick+(0+1-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_5_0_1_rot" x="180.0*0" y="0" z="90" unit="deg"/>
-						<position name="ssdsensor_5_1_0_pos" x="0" y="-18.23" z="(1+0-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1+0-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_5_1_0_pos" x="0" y="-18.23" z="(1+0)*ssdD0_thick+(1-0.5)*mount_thick+(1+0-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_5_1_0_rot" x="180.0*1" y="0" z="0" unit="deg"/>
-						<position name="ssdsensor_5_1_1_pos" x="0" y="18.23" z="(1+1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1+1-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_5_1_1_pos" x="0" y="18.23" z="(1+1)*ssdD0_thick+(1-0.5)*mount_thick+(1+1-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_5_1_1_rot" x="180.0*1" y="0" z="180" unit="deg"/>
-                   <position name="ssdsensor_5_2_0_pos" x="12.92" y="-12.92" z="(0+0.5)*ssdD0_thick+ssd_bkpln_thick+0.5*mount_thick"/>
-						<position name="ssd_bkpln_5_2_0_pos" x="12.92" y="-12.92" z="(0+0.5)*ssd_bkpln_thick+0.5*mount_thick"/>
-					 	<rotation name="ssdsensor_5_2_0_rot" x="180.0*1" y="0" z="45" unit="deg"/>
-                   <position name="ssdsensor_5_2_1_pos" x="-12.92" y="12.92" z="(1+0.5)*ssdD0_thick+ssd_bkpln_thick+0.5*mount_thick"/>
-						<position name="ssd_bkpln_5_2_1_pos" x="-12.92" y="12.92" z="(1+0.5)*ssd_bkpln_thick+0.5*mount_thick"/>
-					 	<rotation name="ssdsensor_5_2_1_rot" x="180.0*1" y="0" z="225" unit="deg"/>
+						<position name="ssdsensor_5_0_0_pos" x="-18.23" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_5_0_0_pos" x="-18.23" y="0" z="(0)*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_5_0_0_rot" x="180.0*0" y="0" z="270" unit="deg"/>
+						<position name="ssdsensor_5_0_1_pos" x="18.23" y="0" z="(1-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(1-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_5_0_1_pos" x="18.23" y="0" z="(1)*ssdD0_thick+(0-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_5_0_1_rot" x="180.0*0" y="0" z="90" unit="deg"/>
+						<position name="ssdsensor_5_1_0_pos" x="0" y="-18.23" z="(0-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_5_1_0_pos" x="0" y="-18.23" z="(0)*ssdD0_thick+(1-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_5_1_0_rot" x="180.0*1" y="0" z="0" unit="deg"/>
+						<position name="ssdsensor_5_1_1_pos" x="0" y="18.23" z="(1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_5_1_1_pos" x="0" y="18.23" z="(1)*ssdD0_thick+(1-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_5_1_1_rot" x="180.0*1" y="0" z="180" unit="deg"/>
+						<position name="ssdsensor_5_2_0_pos" x="12.92" y="-12.92" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_5_2_0_pos" x="12.92" y="-12.92" z="(0)*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_5_2_0_rot" x="180.0*1" y="0" z="45" unit="deg"/>
+						<position name="ssdsensor_5_2_1_pos" x="-12.92" y="12.92" z="(1-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(1-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_5_2_1_pos" x="-12.92" y="12.92" z="(1)*ssdD0_thick+(0-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_5_2_1_rot" x="180.0*1" y="0" z="225" unit="deg"/>
 		<position name="ssdStation6_pos" x="0" y="0" z="ssdStation6_shift+ssdD0_thick-0.5*mount_thick"/>
-						<position name="ssdsensor_6_0_0_pos" x="-18.23" y="0" z="(0+0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0+0-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_6_0_0_pos" x="-18.23" y="0" z="(0+0)*ssdD0_thick+(0-0.5)*mount_thick+(0+0-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_6_0_0_rot" x="180.0*0" y="0" z="270" unit="deg"/>
-						<position name="ssdsensor_6_0_1_pos" x="18.23" y="0" z="(0+1-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0+1-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_6_0_1_pos" x="18.23" y="0" z="(0+1)*ssdD0_thick+(0-0.5)*mount_thick+(0+1-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_6_0_1_rot" x="180.0*0" y="0" z="90" unit="deg"/>
-						<position name="ssdsensor_6_1_0_pos" x="0" y="-18.23" z="(1+0-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1+0-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_6_1_0_pos" x="0" y="-18.23" z="(1+0)*ssdD0_thick+(1-0.5)*mount_thick+(1+0-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_6_1_0_rot" x="180.0*1" y="0" z="0" unit="deg"/>
-						<position name="ssdsensor_6_1_1_pos" x="0" y="18.23" z="(1+1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1+1-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_6_1_1_pos" x="0" y="18.23" z="(1+1)*ssdD0_thick+(1-0.5)*mount_thick+(1+1-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_6_1_1_rot" x="180.0*1" y="0" z="180" unit="deg"/>
-                   <position name="ssdsensor_6_2_0_pos" x="12.92" y="-12.92" z="(0+0.5)*ssdD0_thick+ssd_bkpln_thick+0.5*mount_thick"/>
-						<position name="ssd_bkpln_6_2_0_pos" x="12.92" y="-12.92" z="(0+0.5)*ssd_bkpln_thick+0.5*mount_thick"/>
-					 	<rotation name="ssdsensor_6_2_0_rot" x="180.0*1" y="0" z="45" unit="deg"/>
-                   <position name="ssdsensor_6_2_1_pos" x="-12.92" y="12.92" z="(1+0.5)*ssdD0_thick+ssd_bkpln_thick+0.5*mount_thick"/>
-						<position name="ssd_bkpln_6_2_1_pos" x="-12.92" y="12.92" z="(1+0.5)*ssd_bkpln_thick+0.5*mount_thick"/>
-					 	<rotation name="ssdsensor_6_2_1_rot" x="180.0*1" y="0" z="225" unit="deg"/>
+						<position name="ssdsensor_6_0_0_pos" x="-18.23" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_6_0_0_pos" x="-18.23" y="0" z="(0)*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_6_0_0_rot" x="180.0*0" y="0" z="270" unit="deg"/>
+						<position name="ssdsensor_6_0_1_pos" x="18.23" y="0" z="(1-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(1-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_6_0_1_pos" x="18.23" y="0" z="(1)*ssdD0_thick+(0-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_6_0_1_rot" x="180.0*0" y="0" z="90" unit="deg"/>
+						<position name="ssdsensor_6_1_0_pos" x="0" y="-18.23" z="(0-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_6_1_0_pos" x="0" y="-18.23" z="(0)*ssdD0_thick+(1-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_6_1_0_rot" x="180.0*1" y="0" z="0" unit="deg"/>
+						<position name="ssdsensor_6_1_1_pos" x="0" y="18.23" z="(1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_6_1_1_pos" x="0" y="18.23" z="(1)*ssdD0_thick+(1-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_6_1_1_rot" x="180.0*1" y="0" z="180" unit="deg"/>
+						<position name="ssdsensor_6_2_0_pos" x="12.92" y="-12.92" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_6_2_0_pos" x="12.92" y="-12.92" z="(0)*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_6_2_0_rot" x="180.0*1" y="0" z="45" unit="deg"/>
+						<position name="ssdsensor_6_2_1_pos" x="-12.92" y="12.92" z="(1-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(1-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_6_2_1_pos" x="-12.92" y="12.92" z="(1)*ssdD0_thick+(0-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_6_2_1_rot" x="180.0*1" y="0" z="225" unit="deg"/>
 		<position name="ssdStation7_pos" x="0" y="0" z="ssdStation7_shift+ssdD0_thick-0.5*mount_thick"/>
-						<position name="ssdsensor_7_0_0_pos" x="-18.23" y="0" z="(0+0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0+0-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_7_0_0_pos" x="-18.23" y="0" z="(0+0)*ssdD0_thick+(0-0.5)*mount_thick+(0+0-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_7_0_0_rot" x="180.0*0" y="0" z="270" unit="deg"/>
-						<position name="ssdsensor_7_0_1_pos" x="18.23" y="0" z="(0+1-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0+1-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_7_0_1_pos" x="18.23" y="0" z="(0+1)*ssdD0_thick+(0-0.5)*mount_thick+(0+1-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_7_0_1_rot" x="180.0*0" y="0" z="90" unit="deg"/>
-						<position name="ssdsensor_7_1_0_pos" x="0" y="-18.23" z="(1+0-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1+0-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_7_1_0_pos" x="0" y="-18.23" z="(1+0)*ssdD0_thick+(1-0.5)*mount_thick+(1+0-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_7_1_0_rot" x="180.0*1" y="0" z="0" unit="deg"/>
-						<position name="ssdsensor_7_1_1_pos" x="0" y="19.23" z="(1+1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1+1-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_7_1_1_pos" x="0" y="19.23" z="(1+1)*ssdD0_thick+(1-0.5)*mount_thick+(1+1-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_7_1_1_rot" x="180.0*1" y="0" z="180" unit="deg"/>
+						<position name="ssdsensor_7_0_0_pos" x="-18.23" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_7_0_0_pos" x="-18.23" y="0" z="(0)*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_7_0_0_rot" x="180.0*0" y="0" z="270" unit="deg"/>
+						<position name="ssdsensor_7_0_1_pos" x="18.23" y="0" z="(1-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(1-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_7_0_1_pos" x="18.23" y="0" z="(1)*ssdD0_thick+(0-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_7_0_1_rot" x="180.0*0" y="0" z="90" unit="deg"/>
+						<position name="ssdsensor_7_1_0_pos" x="0" y="-18.23" z="(0-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_7_1_0_pos" x="0" y="-18.23" z="(0)*ssdD0_thick+(1-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_7_1_0_rot" x="180.0*1" y="0" z="0" unit="deg"/>
+						<position name="ssdsensor_7_1_1_pos" x="0" y="19.23" z="(1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_7_1_1_pos" x="0" y="19.23" z="(1)*ssdD0_thick+(1-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_7_1_1_rot" x="180.0*1" y="0" z="180" unit="deg"/>
 				<position name="ssdmount_local_0_0_pos" x="0" y="0" z="0"/>
 				<position name="ssdmount_0_0_pos" x="0" y="0" z="0+0.5*mount_thick"/>
 				<rotation name="ssdmount_0_0_rot" x="-0.44" y="-2.02" unit="deg"/>
@@ -242,8 +242,8 @@
 				<position name="ssdmount_7_0_pos" x="0" y="0" z="0+0.5*mount_thick"/>
 				<rotation name="ssdmount_7_0_rot" x="0.36" y="0.31" unit="deg"/>
 
-	 <position name="ssd_USMylarWindow_pos" x="0" y="0" z="Mylar_shift"/>
-	 <position name="ssd_DSMylarWindow_pos" x="0" y="0" z="-1.*Mylar_shift"/>
+	 <position name="ssd_USMylarWindow_pos" x="0" y="0" z="-1*Mylar_shift"/>
+	 <position name="ssd_DSMylarWindow_pos" x="0" y="0" z="Mylar_shift"/>
 
 
 		<position name="ssd_mount_u1_pos" x="70" y="0" z="0"/>
@@ -254,8 +254,8 @@
 		<position name="ssd_mount_u4_pos" x="80.1" y="-80.4"/>
 		<rotation name="ssd_mount_u4_rot" y="-90" z="135" unit="deg"/>
 
-	 <position name="ssd_mount_out_pos1" z="0.5*mount_thick+0.5*ssdD0_thick+0.5*ssd_bkpln_thick" unit="mm" />
-	 <position name="ssd_mount_out_pos2" z="-0.5*mount_thick-0.5*ssdD0_thick-0.5*ssd_bkpln_thick" unit="mm" />
+	 <position name="ssd_mount_out_pos1" z="0.5*mount_thick" unit="mm" />
+	 <position name="ssd_mount_out_pos2" z="-0.5*mount_thick" unit="mm" />
 
 	 <quantity name="ssdStationrotateLength" value="50" unit="mm" />
 	 <quantity name="ssdStationrotateWidth" value="300" unit="mm" />
@@ -2160,7 +2160,7 @@ values="202.14067278287462 12.054573032169143
 		<second ref="ssd_mount_box2"/>
 	 </subtraction>
 
-	 <box name="ssd_mount_out_box" x="1.2*mount_width" y="1.2*mount_width" z="ssdD0_thick+ssd_bkpln_thick" />
+	 <box name="ssd_mount_out_box" x="1.2*mount_width" y="1.2*mount_width" z="2*ssdD0_thick+2*ssd_bkpln_thick" />
 	 <union name="ssd_mount_enclosure_u1">
 	   <first ref="ssd_mount_box"/>
 		<second ref="ssd_mount_out_box"/>

--- a/ConstBase/Geometry/phase1c-Graphite.gdml
+++ b/ConstBase/Geometry/phase1c-Graphite.gdml
@@ -114,97 +114,97 @@
 	 <quantity name="ssdStationsingleHeight" value="300" unit="mm" />
 
 		<position name="ssdStation0_pos" x="0" y="0" z="ssdStation0_shift+ssdD0_thick-0.5*mount_thick"/>
-						<position name="ssdsensor_0_0_0_pos" x="0" y="0" z="(0+0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0+0-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_0_0_0_pos" x="0" y="0" z="(0+0)*ssdD0_thick+(0-0.5)*mount_thick+(0+0-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_0_0_0_rot" x="180.0*0" y="0" z="0" unit="deg"/>
-						<position name="ssdsensor_0_1_0_pos" x="0" y="0" z="(1+0-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1+0-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_0_1_0_pos" x="0" y="0" z="(1+0)*ssdD0_thick+(1-0.5)*mount_thick+(1+0-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_0_1_0_rot" x="180.0*1" y="0" z="90" unit="deg"/>
+						<position name="ssdsensor_0_0_0_pos" x="0" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_0_0_0_pos" x="0" y="0" z="(0)*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_0_0_0_rot" x="180.0*0" y="0" z="0" unit="deg"/>
+						<position name="ssdsensor_0_1_0_pos" x="0" y="0" z="(0-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_0_1_0_pos" x="0" y="0" z="(0)*ssdD0_thick+(1-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_0_1_0_rot" x="180.0*1" y="0" z="90" unit="deg"/>
 		<position name="ssdStation1_pos" x="0" y="0" z="ssdStation1_shift+ssdD0_thick-0.5*mount_thick"/>
-						<position name="ssdsensor_1_0_0_pos" x="0" y="0" z="(0+0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0+0-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_1_0_0_pos" x="0" y="0" z="(0+0)*ssdD0_thick+(0-0.5)*mount_thick+(0+0-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_1_0_0_rot" x="180.0*0" y="0" z="0" unit="deg"/>
-						<position name="ssdsensor_1_1_0_pos" x="0" y="0" z="(1+0-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1+0-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_1_1_0_pos" x="0" y="0" z="(1+0)*ssdD0_thick+(1-0.5)*mount_thick+(1+0-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_1_1_0_rot" x="180.0*1" y="0" z="90" unit="deg"/>
+						<position name="ssdsensor_1_0_0_pos" x="0" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_1_0_0_pos" x="0" y="0" z="(0)*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_1_0_0_rot" x="180.0*0" y="0" z="0" unit="deg"/>
+						<position name="ssdsensor_1_1_0_pos" x="0" y="0" z="(0-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_1_1_0_pos" x="0" y="0" z="(0)*ssdD0_thick+(1-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_1_1_0_rot" x="180.0*1" y="0" z="90" unit="deg"/>
 		<position name="ssdStation2_pos" x="0" y="0" z="ssdStation2_shift+ssdD0_thick-0.5*mount_thick"/>
-						<position name="ssdsensor_2_0_0_pos" x="0" y="0" z="(0+0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0+0-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_2_0_0_pos" x="0" y="0" z="(0+0)*ssdD0_thick+(0-0.5)*mount_thick+(0+0-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_2_0_0_rot" x="180.0*0" y="0" z="315" unit="deg"/>
-						<position name="ssdsensor_2_1_0_pos" x="0" y="0" z="(1+0-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1+0-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_2_1_0_pos" x="0" y="0" z="(1+0)*ssdD0_thick+(1-0.5)*mount_thick+(1+0-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_2_1_0_rot" x="180.0*0" y="0" z="0" unit="deg"/>
-                   <position name="ssdsensor_2_2_0_pos" x="0" y="0" z="(0+0.5)*ssdD0_thick+ssd_bkpln_thick+0.5*mount_thick"/>
-						<position name="ssd_bkpln_2_2_0_pos" x="0" y="0" z="(0+0.5)*ssd_bkpln_thick+0.5*mount_thick"/>
-					 	<rotation name="ssdsensor_2_2_0_rot" x="180.0*1" y="0" z="90" unit="deg"/>
+						<position name="ssdsensor_2_0_0_pos" x="0" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_2_0_0_pos" x="0" y="0" z="(0)*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_2_0_0_rot" x="180.0*0" y="0" z="315" unit="deg"/>
+						<position name="ssdsensor_2_1_0_pos" x="0" y="0" z="(0-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_2_1_0_pos" x="0" y="0" z="(0)*ssdD0_thick+(1-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_2_1_0_rot" x="180.0*0" y="0" z="0" unit="deg"/>
+						<position name="ssdsensor_2_2_0_pos" x="0" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_2_2_0_pos" x="0" y="0" z="(0)*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_2_2_0_rot" x="180.0*1" y="0" z="90" unit="deg"/>
 		<position name="ssdStation3_pos" x="0" y="0" z="ssdStation3_shift+ssdD0_thick-0.5*mount_thick"/>
-						<position name="ssdsensor_3_0_0_pos" x="0" y="0" z="(0+0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0+0-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_3_0_0_pos" x="0" y="0" z="(0+0)*ssdD0_thick+(0-0.5)*mount_thick+(0+0-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_3_0_0_rot" x="180.0*0" y="0" z="315" unit="deg"/>
-						<position name="ssdsensor_3_1_0_pos" x="0" y="0" z="(1+0-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1+0-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_3_1_0_pos" x="0" y="0" z="(1+0)*ssdD0_thick+(1-0.5)*mount_thick+(1+0-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_3_1_0_rot" x="180.0*0" y="0" z="0" unit="deg"/>
-                   <position name="ssdsensor_3_2_0_pos" x="0" y="0" z="(0+0.5)*ssdD0_thick+ssd_bkpln_thick+0.5*mount_thick"/>
-						<position name="ssd_bkpln_3_2_0_pos" x="0" y="0" z="(0+0.5)*ssd_bkpln_thick+0.5*mount_thick"/>
-					 	<rotation name="ssdsensor_3_2_0_rot" x="180.0*1" y="0" z="90" unit="deg"/>
+						<position name="ssdsensor_3_0_0_pos" x="0" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_3_0_0_pos" x="0" y="0" z="(0)*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_3_0_0_rot" x="180.0*0" y="0" z="315" unit="deg"/>
+						<position name="ssdsensor_3_1_0_pos" x="0" y="0" z="(0-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_3_1_0_pos" x="0" y="0" z="(0)*ssdD0_thick+(1-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_3_1_0_rot" x="180.0*0" y="0" z="0" unit="deg"/>
+						<position name="ssdsensor_3_2_0_pos" x="0" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_3_2_0_pos" x="0" y="0" z="(0)*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_3_2_0_rot" x="180.0*1" y="0" z="90" unit="deg"/>
 		<position name="ssdStation4_pos" x="0" y="0" z="ssdStation4_shift+ssdD0_thick-0.5*mount_thick"/>
-						<position name="ssdsensor_4_0_0_pos" x="0" y="0" z="(0+0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0+0-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_4_0_0_pos" x="0" y="0" z="(0+0)*ssdD0_thick+(0-0.5)*mount_thick+(0+0-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_4_0_0_rot" x="180.0*0" y="0" z="0" unit="deg"/>
-						<position name="ssdsensor_4_1_0_pos" x="0" y="0" z="(1+0-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1+0-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_4_1_0_pos" x="0" y="0" z="(1+0)*ssdD0_thick+(1-0.5)*mount_thick+(1+0-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_4_1_0_rot" x="180.0*1" y="0" z="90" unit="deg"/>
+						<position name="ssdsensor_4_0_0_pos" x="0" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_4_0_0_pos" x="0" y="0" z="(0)*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_4_0_0_rot" x="180.0*0" y="0" z="0" unit="deg"/>
+						<position name="ssdsensor_4_1_0_pos" x="0" y="0" z="(0-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_4_1_0_pos" x="0" y="0" z="(0)*ssdD0_thick+(1-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_4_1_0_rot" x="180.0*1" y="0" z="90" unit="deg"/>
 		<position name="ssdStation5_pos" x="0" y="0" z="ssdStation5_shift+ssdD0_thick-0.5*mount_thick"/>
-						<position name="ssdsensor_5_0_0_pos" x="-18.23" y="0" z="(0+0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0+0-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_5_0_0_pos" x="-18.23" y="0" z="(0+0)*ssdD0_thick+(0-0.5)*mount_thick+(0+0-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_5_0_0_rot" x="180.0*0" y="0" z="270" unit="deg"/>
-						<position name="ssdsensor_5_0_1_pos" x="18.23" y="0" z="(0+1-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0+1-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_5_0_1_pos" x="18.23" y="0" z="(0+1)*ssdD0_thick+(0-0.5)*mount_thick+(0+1-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_5_0_1_rot" x="180.0*0" y="0" z="90" unit="deg"/>
-						<position name="ssdsensor_5_1_0_pos" x="0" y="-18.23" z="(1+0-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1+0-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_5_1_0_pos" x="0" y="-18.23" z="(1+0)*ssdD0_thick+(1-0.5)*mount_thick+(1+0-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_5_1_0_rot" x="180.0*1" y="0" z="0" unit="deg"/>
-						<position name="ssdsensor_5_1_1_pos" x="0" y="18.23" z="(1+1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1+1-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_5_1_1_pos" x="0" y="18.23" z="(1+1)*ssdD0_thick+(1-0.5)*mount_thick+(1+1-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_5_1_1_rot" x="180.0*1" y="0" z="180" unit="deg"/>
-                   <position name="ssdsensor_5_2_0_pos" x="12.92" y="-12.92" z="(0+0.5)*ssdD0_thick+ssd_bkpln_thick+0.5*mount_thick"/>
-						<position name="ssd_bkpln_5_2_0_pos" x="12.92" y="-12.92" z="(0+0.5)*ssd_bkpln_thick+0.5*mount_thick"/>
-					 	<rotation name="ssdsensor_5_2_0_rot" x="180.0*1" y="0" z="45" unit="deg"/>
-                   <position name="ssdsensor_5_2_1_pos" x="-12.92" y="12.92" z="(1+0.5)*ssdD0_thick+ssd_bkpln_thick+0.5*mount_thick"/>
-						<position name="ssd_bkpln_5_2_1_pos" x="-12.92" y="12.92" z="(1+0.5)*ssd_bkpln_thick+0.5*mount_thick"/>
-					 	<rotation name="ssdsensor_5_2_1_rot" x="180.0*1" y="0" z="225" unit="deg"/>
+						<position name="ssdsensor_5_0_0_pos" x="-18.23" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_5_0_0_pos" x="-18.23" y="0" z="(0)*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_5_0_0_rot" x="180.0*0" y="0" z="270" unit="deg"/>
+						<position name="ssdsensor_5_0_1_pos" x="18.23" y="0" z="(1-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(1-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_5_0_1_pos" x="18.23" y="0" z="(1)*ssdD0_thick+(0-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_5_0_1_rot" x="180.0*0" y="0" z="90" unit="deg"/>
+						<position name="ssdsensor_5_1_0_pos" x="0" y="-18.23" z="(0-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_5_1_0_pos" x="0" y="-18.23" z="(0)*ssdD0_thick+(1-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_5_1_0_rot" x="180.0*1" y="0" z="0" unit="deg"/>
+						<position name="ssdsensor_5_1_1_pos" x="0" y="18.23" z="(1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_5_1_1_pos" x="0" y="18.23" z="(1)*ssdD0_thick+(1-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_5_1_1_rot" x="180.0*1" y="0" z="180" unit="deg"/>
+						<position name="ssdsensor_5_2_0_pos" x="12.92" y="-12.92" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_5_2_0_pos" x="12.92" y="-12.92" z="(0)*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_5_2_0_rot" x="180.0*1" y="0" z="45" unit="deg"/>
+						<position name="ssdsensor_5_2_1_pos" x="-12.92" y="12.92" z="(1-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(1-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_5_2_1_pos" x="-12.92" y="12.92" z="(1)*ssdD0_thick+(0-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_5_2_1_rot" x="180.0*1" y="0" z="225" unit="deg"/>
 		<position name="ssdStation6_pos" x="0" y="0" z="ssdStation6_shift+ssdD0_thick-0.5*mount_thick"/>
-						<position name="ssdsensor_6_0_0_pos" x="-18.23" y="0" z="(0+0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0+0-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_6_0_0_pos" x="-18.23" y="0" z="(0+0)*ssdD0_thick+(0-0.5)*mount_thick+(0+0-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_6_0_0_rot" x="180.0*0" y="0" z="270" unit="deg"/>
-						<position name="ssdsensor_6_0_1_pos" x="18.23" y="0" z="(0+1-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0+1-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_6_0_1_pos" x="18.23" y="0" z="(0+1)*ssdD0_thick+(0-0.5)*mount_thick+(0+1-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_6_0_1_rot" x="180.0*0" y="0" z="90" unit="deg"/>
-						<position name="ssdsensor_6_1_0_pos" x="0" y="-18.23" z="(1+0-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1+0-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_6_1_0_pos" x="0" y="-18.23" z="(1+0)*ssdD0_thick+(1-0.5)*mount_thick+(1+0-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_6_1_0_rot" x="180.0*1" y="0" z="0" unit="deg"/>
-						<position name="ssdsensor_6_1_1_pos" x="0" y="18.23" z="(1+1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1+1-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_6_1_1_pos" x="0" y="18.23" z="(1+1)*ssdD0_thick+(1-0.5)*mount_thick+(1+1-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_6_1_1_rot" x="180.0*1" y="0" z="180" unit="deg"/>
-                   <position name="ssdsensor_6_2_0_pos" x="12.92" y="-12.92" z="(0+0.5)*ssdD0_thick+ssd_bkpln_thick+0.5*mount_thick"/>
-						<position name="ssd_bkpln_6_2_0_pos" x="12.92" y="-12.92" z="(0+0.5)*ssd_bkpln_thick+0.5*mount_thick"/>
-					 	<rotation name="ssdsensor_6_2_0_rot" x="180.0*1" y="0" z="45" unit="deg"/>
-                   <position name="ssdsensor_6_2_1_pos" x="-12.92" y="12.92" z="(1+0.5)*ssdD0_thick+ssd_bkpln_thick+0.5*mount_thick"/>
-						<position name="ssd_bkpln_6_2_1_pos" x="-12.92" y="12.92" z="(1+0.5)*ssd_bkpln_thick+0.5*mount_thick"/>
-					 	<rotation name="ssdsensor_6_2_1_rot" x="180.0*1" y="0" z="225" unit="deg"/>
+						<position name="ssdsensor_6_0_0_pos" x="-18.23" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_6_0_0_pos" x="-18.23" y="0" z="(0)*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_6_0_0_rot" x="180.0*0" y="0" z="270" unit="deg"/>
+						<position name="ssdsensor_6_0_1_pos" x="18.23" y="0" z="(1-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(1-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_6_0_1_pos" x="18.23" y="0" z="(1)*ssdD0_thick+(0-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_6_0_1_rot" x="180.0*0" y="0" z="90" unit="deg"/>
+						<position name="ssdsensor_6_1_0_pos" x="0" y="-18.23" z="(0-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_6_1_0_pos" x="0" y="-18.23" z="(0)*ssdD0_thick+(1-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_6_1_0_rot" x="180.0*1" y="0" z="0" unit="deg"/>
+						<position name="ssdsensor_6_1_1_pos" x="0" y="18.23" z="(1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_6_1_1_pos" x="0" y="18.23" z="(1)*ssdD0_thick+(1-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_6_1_1_rot" x="180.0*1" y="0" z="180" unit="deg"/>
+						<position name="ssdsensor_6_2_0_pos" x="12.92" y="-12.92" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_6_2_0_pos" x="12.92" y="-12.92" z="(0)*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_6_2_0_rot" x="180.0*1" y="0" z="45" unit="deg"/>
+						<position name="ssdsensor_6_2_1_pos" x="-12.92" y="12.92" z="(1-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(1-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_6_2_1_pos" x="-12.92" y="12.92" z="(1)*ssdD0_thick+(0-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_6_2_1_rot" x="180.0*1" y="0" z="225" unit="deg"/>
 		<position name="ssdStation7_pos" x="0" y="0" z="ssdStation7_shift+ssdD0_thick-0.5*mount_thick"/>
-						<position name="ssdsensor_7_0_0_pos" x="-18.23" y="0" z="(0+0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0+0-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_7_0_0_pos" x="-18.23" y="0" z="(0+0)*ssdD0_thick+(0-0.5)*mount_thick+(0+0-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_7_0_0_rot" x="180.0*0" y="0" z="270" unit="deg"/>
-						<position name="ssdsensor_7_0_1_pos" x="18.23" y="0" z="(0+1-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0+1-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_7_0_1_pos" x="18.23" y="0" z="(0+1)*ssdD0_thick+(0-0.5)*mount_thick+(0+1-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_7_0_1_rot" x="180.0*0" y="0" z="90" unit="deg"/>
-						<position name="ssdsensor_7_1_0_pos" x="0" y="-18.23" z="(1+0-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1+0-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_7_1_0_pos" x="0" y="-18.23" z="(1+0)*ssdD0_thick+(1-0.5)*mount_thick+(1+0-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_7_1_0_rot" x="180.0*1" y="0" z="0" unit="deg"/>
-						<position name="ssdsensor_7_1_1_pos" x="0" y="19.23" z="(1+1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1+1-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_7_1_1_pos" x="0" y="19.23" z="(1+1)*ssdD0_thick+(1-0.5)*mount_thick+(1+1-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_7_1_1_rot" x="180.0*1" y="0" z="180" unit="deg"/>
+						<position name="ssdsensor_7_0_0_pos" x="-18.23" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_7_0_0_pos" x="-18.23" y="0" z="(0)*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_7_0_0_rot" x="180.0*0" y="0" z="270" unit="deg"/>
+						<position name="ssdsensor_7_0_1_pos" x="18.23" y="0" z="(1-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(1-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_7_0_1_pos" x="18.23" y="0" z="(1)*ssdD0_thick+(0-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_7_0_1_rot" x="180.0*0" y="0" z="90" unit="deg"/>
+						<position name="ssdsensor_7_1_0_pos" x="0" y="-18.23" z="(0-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_7_1_0_pos" x="0" y="-18.23" z="(0)*ssdD0_thick+(1-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_7_1_0_rot" x="180.0*1" y="0" z="0" unit="deg"/>
+						<position name="ssdsensor_7_1_1_pos" x="0" y="19.23" z="(1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_7_1_1_pos" x="0" y="19.23" z="(1)*ssdD0_thick+(1-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_7_1_1_rot" x="180.0*1" y="0" z="180" unit="deg"/>
 				<position name="ssdmount_local_0_0_pos" x="0" y="0" z="0"/>
 				<position name="ssdmount_0_0_pos" x="0" y="0" z="0+0.5*mount_thick"/>
 				<rotation name="ssdmount_0_0_rot" x="-0.44" y="-2.02" unit="deg"/>
@@ -242,8 +242,8 @@
 				<position name="ssdmount_7_0_pos" x="0" y="0" z="0+0.5*mount_thick"/>
 				<rotation name="ssdmount_7_0_rot" x="0.36" y="0.31" unit="deg"/>
 
-	 <position name="ssd_USMylarWindow_pos" x="0" y="0" z="Mylar_shift"/>
-	 <position name="ssd_DSMylarWindow_pos" x="0" y="0" z="-1.*Mylar_shift"/>
+	 <position name="ssd_USMylarWindow_pos" x="0" y="0" z="-1*Mylar_shift"/>
+	 <position name="ssd_DSMylarWindow_pos" x="0" y="0" z="Mylar_shift"/>
 
 
 		<position name="ssd_mount_u1_pos" x="70" y="0" z="0"/>
@@ -254,8 +254,8 @@
 		<position name="ssd_mount_u4_pos" x="80.1" y="-80.4"/>
 		<rotation name="ssd_mount_u4_rot" y="-90" z="135" unit="deg"/>
 
-	 <position name="ssd_mount_out_pos1" z="0.5*mount_thick+0.5*ssdD0_thick+0.5*ssd_bkpln_thick" unit="mm" />
-	 <position name="ssd_mount_out_pos2" z="-0.5*mount_thick-0.5*ssdD0_thick-0.5*ssd_bkpln_thick" unit="mm" />
+	 <position name="ssd_mount_out_pos1" z="0.5*mount_thick" unit="mm" />
+	 <position name="ssd_mount_out_pos2" z="-0.5*mount_thick" unit="mm" />
 
 	 <quantity name="ssdStationrotateLength" value="50" unit="mm" />
 	 <quantity name="ssdStationrotateWidth" value="300" unit="mm" />
@@ -2160,7 +2160,7 @@ values="202.14067278287462 12.054573032169143
 		<second ref="ssd_mount_box2"/>
 	 </subtraction>
 
-	 <box name="ssd_mount_out_box" x="1.2*mount_width" y="1.2*mount_width" z="ssdD0_thick+ssd_bkpln_thick" />
+	 <box name="ssd_mount_out_box" x="1.2*mount_width" y="1.2*mount_width" z="2*ssdD0_thick+2*ssd_bkpln_thick" />
 	 <union name="ssd_mount_enclosure_u1">
 	   <first ref="ssd_mount_box"/>
 		<second ref="ssd_mount_out_box"/>

--- a/ConstBase/Geometry/phase1c.gdml
+++ b/ConstBase/Geometry/phase1c.gdml
@@ -114,97 +114,97 @@
 	 <quantity name="ssdStationsingleHeight" value="300" unit="mm" />
 
 		<position name="ssdStation0_pos" x="0" y="0" z="ssdStation0_shift+ssdD0_thick-0.5*mount_thick"/>
-						<position name="ssdsensor_0_0_0_pos" x="0" y="0" z="(0+0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0+0-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_0_0_0_pos" x="0" y="0" z="(0+0)*ssdD0_thick+(0-0.5)*mount_thick+(0+0-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_0_0_0_rot" x="180.0*0" y="0" z="0" unit="deg"/>
-						<position name="ssdsensor_0_1_0_pos" x="0" y="0" z="(1+0-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1+0-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_0_1_0_pos" x="0" y="0" z="(1+0)*ssdD0_thick+(1-0.5)*mount_thick+(1+0-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_0_1_0_rot" x="180.0*1" y="0" z="90" unit="deg"/>
+						<position name="ssdsensor_0_0_0_pos" x="0" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_0_0_0_pos" x="0" y="0" z="(0)*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_0_0_0_rot" x="180.0*0" y="0" z="0" unit="deg"/>
+						<position name="ssdsensor_0_1_0_pos" x="0" y="0" z="(0-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_0_1_0_pos" x="0" y="0" z="(0)*ssdD0_thick+(1-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_0_1_0_rot" x="180.0*1" y="0" z="90" unit="deg"/>
 		<position name="ssdStation1_pos" x="0" y="0" z="ssdStation1_shift+ssdD0_thick-0.5*mount_thick"/>
-						<position name="ssdsensor_1_0_0_pos" x="0" y="0" z="(0+0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0+0-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_1_0_0_pos" x="0" y="0" z="(0+0)*ssdD0_thick+(0-0.5)*mount_thick+(0+0-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_1_0_0_rot" x="180.0*0" y="0" z="0" unit="deg"/>
-						<position name="ssdsensor_1_1_0_pos" x="0" y="0" z="(1+0-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1+0-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_1_1_0_pos" x="0" y="0" z="(1+0)*ssdD0_thick+(1-0.5)*mount_thick+(1+0-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_1_1_0_rot" x="180.0*1" y="0" z="90" unit="deg"/>
+						<position name="ssdsensor_1_0_0_pos" x="0" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_1_0_0_pos" x="0" y="0" z="(0)*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_1_0_0_rot" x="180.0*0" y="0" z="0" unit="deg"/>
+						<position name="ssdsensor_1_1_0_pos" x="0" y="0" z="(0-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_1_1_0_pos" x="0" y="0" z="(0)*ssdD0_thick+(1-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_1_1_0_rot" x="180.0*1" y="0" z="90" unit="deg"/>
 		<position name="ssdStation2_pos" x="0" y="0" z="ssdStation2_shift+ssdD0_thick-0.5*mount_thick"/>
-						<position name="ssdsensor_2_0_0_pos" x="0" y="0" z="(0+0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0+0-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_2_0_0_pos" x="0" y="0" z="(0+0)*ssdD0_thick+(0-0.5)*mount_thick+(0+0-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_2_0_0_rot" x="180.0*0" y="0" z="315" unit="deg"/>
-						<position name="ssdsensor_2_1_0_pos" x="0" y="0" z="(1+0-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1+0-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_2_1_0_pos" x="0" y="0" z="(1+0)*ssdD0_thick+(1-0.5)*mount_thick+(1+0-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_2_1_0_rot" x="180.0*0" y="0" z="0" unit="deg"/>
-                   <position name="ssdsensor_2_2_0_pos" x="0" y="0" z="(0+0.5)*ssdD0_thick+ssd_bkpln_thick+0.5*mount_thick"/>
-						<position name="ssd_bkpln_2_2_0_pos" x="0" y="0" z="(0+0.5)*ssd_bkpln_thick+0.5*mount_thick"/>
-					 	<rotation name="ssdsensor_2_2_0_rot" x="180.0*1" y="0" z="90" unit="deg"/>
+						<position name="ssdsensor_2_0_0_pos" x="0" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_2_0_0_pos" x="0" y="0" z="(0)*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_2_0_0_rot" x="180.0*0" y="0" z="315" unit="deg"/>
+						<position name="ssdsensor_2_1_0_pos" x="0" y="0" z="(0-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_2_1_0_pos" x="0" y="0" z="(0)*ssdD0_thick+(1-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_2_1_0_rot" x="180.0*0" y="0" z="0" unit="deg"/>
+						<position name="ssdsensor_2_2_0_pos" x="0" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_2_2_0_pos" x="0" y="0" z="(0)*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_2_2_0_rot" x="180.0*1" y="0" z="90" unit="deg"/>
 		<position name="ssdStation3_pos" x="0" y="0" z="ssdStation3_shift+ssdD0_thick-0.5*mount_thick"/>
-						<position name="ssdsensor_3_0_0_pos" x="0" y="0" z="(0+0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0+0-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_3_0_0_pos" x="0" y="0" z="(0+0)*ssdD0_thick+(0-0.5)*mount_thick+(0+0-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_3_0_0_rot" x="180.0*0" y="0" z="315" unit="deg"/>
-						<position name="ssdsensor_3_1_0_pos" x="0" y="0" z="(1+0-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1+0-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_3_1_0_pos" x="0" y="0" z="(1+0)*ssdD0_thick+(1-0.5)*mount_thick+(1+0-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_3_1_0_rot" x="180.0*0" y="0" z="0" unit="deg"/>
-                   <position name="ssdsensor_3_2_0_pos" x="0" y="0" z="(0+0.5)*ssdD0_thick+ssd_bkpln_thick+0.5*mount_thick"/>
-						<position name="ssd_bkpln_3_2_0_pos" x="0" y="0" z="(0+0.5)*ssd_bkpln_thick+0.5*mount_thick"/>
-					 	<rotation name="ssdsensor_3_2_0_rot" x="180.0*1" y="0" z="90" unit="deg"/>
+						<position name="ssdsensor_3_0_0_pos" x="0" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_3_0_0_pos" x="0" y="0" z="(0)*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_3_0_0_rot" x="180.0*0" y="0" z="315" unit="deg"/>
+						<position name="ssdsensor_3_1_0_pos" x="0" y="0" z="(0-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_3_1_0_pos" x="0" y="0" z="(0)*ssdD0_thick+(1-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_3_1_0_rot" x="180.0*0" y="0" z="0" unit="deg"/>
+						<position name="ssdsensor_3_2_0_pos" x="0" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_3_2_0_pos" x="0" y="0" z="(0)*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_3_2_0_rot" x="180.0*1" y="0" z="90" unit="deg"/>
 		<position name="ssdStation4_pos" x="0" y="0" z="ssdStation4_shift+ssdD0_thick-0.5*mount_thick"/>
-						<position name="ssdsensor_4_0_0_pos" x="0" y="0" z="(0+0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0+0-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_4_0_0_pos" x="0" y="0" z="(0+0)*ssdD0_thick+(0-0.5)*mount_thick+(0+0-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_4_0_0_rot" x="180.0*0" y="0" z="0" unit="deg"/>
-						<position name="ssdsensor_4_1_0_pos" x="0" y="0" z="(1+0-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1+0-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_4_1_0_pos" x="0" y="0" z="(1+0)*ssdD0_thick+(1-0.5)*mount_thick+(1+0-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_4_1_0_rot" x="180.0*1" y="0" z="90" unit="deg"/>
+						<position name="ssdsensor_4_0_0_pos" x="0" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_4_0_0_pos" x="0" y="0" z="(0)*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_4_0_0_rot" x="180.0*0" y="0" z="0" unit="deg"/>
+						<position name="ssdsensor_4_1_0_pos" x="0" y="0" z="(0-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_4_1_0_pos" x="0" y="0" z="(0)*ssdD0_thick+(1-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_4_1_0_rot" x="180.0*1" y="0" z="90" unit="deg"/>
 		<position name="ssdStation5_pos" x="0" y="0" z="ssdStation5_shift+ssdD0_thick-0.5*mount_thick"/>
-						<position name="ssdsensor_5_0_0_pos" x="-18.23" y="0" z="(0+0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0+0-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_5_0_0_pos" x="-18.23" y="0" z="(0+0)*ssdD0_thick+(0-0.5)*mount_thick+(0+0-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_5_0_0_rot" x="180.0*0" y="0" z="270" unit="deg"/>
-						<position name="ssdsensor_5_0_1_pos" x="18.23" y="0" z="(0+1-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0+1-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_5_0_1_pos" x="18.23" y="0" z="(0+1)*ssdD0_thick+(0-0.5)*mount_thick+(0+1-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_5_0_1_rot" x="180.0*0" y="0" z="90" unit="deg"/>
-						<position name="ssdsensor_5_1_0_pos" x="0" y="-18.23" z="(1+0-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1+0-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_5_1_0_pos" x="0" y="-18.23" z="(1+0)*ssdD0_thick+(1-0.5)*mount_thick+(1+0-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_5_1_0_rot" x="180.0*1" y="0" z="0" unit="deg"/>
-						<position name="ssdsensor_5_1_1_pos" x="0" y="18.23" z="(1+1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1+1-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_5_1_1_pos" x="0" y="18.23" z="(1+1)*ssdD0_thick+(1-0.5)*mount_thick+(1+1-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_5_1_1_rot" x="180.0*1" y="0" z="180" unit="deg"/>
-                   <position name="ssdsensor_5_2_0_pos" x="12.92" y="-12.92" z="(0+0.5)*ssdD0_thick+ssd_bkpln_thick+0.5*mount_thick"/>
-						<position name="ssd_bkpln_5_2_0_pos" x="12.92" y="-12.92" z="(0+0.5)*ssd_bkpln_thick+0.5*mount_thick"/>
-					 	<rotation name="ssdsensor_5_2_0_rot" x="180.0*1" y="0" z="45" unit="deg"/>
-                   <position name="ssdsensor_5_2_1_pos" x="-12.92" y="12.92" z="(1+0.5)*ssdD0_thick+ssd_bkpln_thick+0.5*mount_thick"/>
-						<position name="ssd_bkpln_5_2_1_pos" x="-12.92" y="12.92" z="(1+0.5)*ssd_bkpln_thick+0.5*mount_thick"/>
-					 	<rotation name="ssdsensor_5_2_1_rot" x="180.0*1" y="0" z="225" unit="deg"/>
+						<position name="ssdsensor_5_0_0_pos" x="-18.23" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_5_0_0_pos" x="-18.23" y="0" z="(0)*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_5_0_0_rot" x="180.0*0" y="0" z="270" unit="deg"/>
+						<position name="ssdsensor_5_0_1_pos" x="18.23" y="0" z="(1-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(1-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_5_0_1_pos" x="18.23" y="0" z="(1)*ssdD0_thick+(0-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_5_0_1_rot" x="180.0*0" y="0" z="90" unit="deg"/>
+						<position name="ssdsensor_5_1_0_pos" x="0" y="-18.23" z="(0-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_5_1_0_pos" x="0" y="-18.23" z="(0)*ssdD0_thick+(1-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_5_1_0_rot" x="180.0*1" y="0" z="0" unit="deg"/>
+						<position name="ssdsensor_5_1_1_pos" x="0" y="18.23" z="(1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_5_1_1_pos" x="0" y="18.23" z="(1)*ssdD0_thick+(1-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_5_1_1_rot" x="180.0*1" y="0" z="180" unit="deg"/>
+						<position name="ssdsensor_5_2_0_pos" x="12.92" y="-12.92" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_5_2_0_pos" x="12.92" y="-12.92" z="(0)*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_5_2_0_rot" x="180.0*1" y="0" z="45" unit="deg"/>
+						<position name="ssdsensor_5_2_1_pos" x="-12.92" y="12.92" z="(1-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(1-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_5_2_1_pos" x="-12.92" y="12.92" z="(1)*ssdD0_thick+(0-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_5_2_1_rot" x="180.0*1" y="0" z="225" unit="deg"/>
 		<position name="ssdStation6_pos" x="0" y="0" z="ssdStation6_shift+ssdD0_thick-0.5*mount_thick"/>
-						<position name="ssdsensor_6_0_0_pos" x="-18.23" y="0" z="(0+0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0+0-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_6_0_0_pos" x="-18.23" y="0" z="(0+0)*ssdD0_thick+(0-0.5)*mount_thick+(0+0-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_6_0_0_rot" x="180.0*0" y="0" z="270" unit="deg"/>
-						<position name="ssdsensor_6_0_1_pos" x="18.23" y="0" z="(0+1-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0+1-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_6_0_1_pos" x="18.23" y="0" z="(0+1)*ssdD0_thick+(0-0.5)*mount_thick+(0+1-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_6_0_1_rot" x="180.0*0" y="0" z="90" unit="deg"/>
-						<position name="ssdsensor_6_1_0_pos" x="0" y="-18.23" z="(1+0-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1+0-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_6_1_0_pos" x="0" y="-18.23" z="(1+0)*ssdD0_thick+(1-0.5)*mount_thick+(1+0-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_6_1_0_rot" x="180.0*1" y="0" z="0" unit="deg"/>
-						<position name="ssdsensor_6_1_1_pos" x="0" y="18.23" z="(1+1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1+1-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_6_1_1_pos" x="0" y="18.23" z="(1+1)*ssdD0_thick+(1-0.5)*mount_thick+(1+1-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_6_1_1_rot" x="180.0*1" y="0" z="180" unit="deg"/>
-                   <position name="ssdsensor_6_2_0_pos" x="12.92" y="-12.92" z="(0+0.5)*ssdD0_thick+ssd_bkpln_thick+0.5*mount_thick"/>
-						<position name="ssd_bkpln_6_2_0_pos" x="12.92" y="-12.92" z="(0+0.5)*ssd_bkpln_thick+0.5*mount_thick"/>
-					 	<rotation name="ssdsensor_6_2_0_rot" x="180.0*1" y="0" z="45" unit="deg"/>
-                   <position name="ssdsensor_6_2_1_pos" x="-12.92" y="12.92" z="(1+0.5)*ssdD0_thick+ssd_bkpln_thick+0.5*mount_thick"/>
-						<position name="ssd_bkpln_6_2_1_pos" x="-12.92" y="12.92" z="(1+0.5)*ssd_bkpln_thick+0.5*mount_thick"/>
-					 	<rotation name="ssdsensor_6_2_1_rot" x="180.0*1" y="0" z="225" unit="deg"/>
+						<position name="ssdsensor_6_0_0_pos" x="-18.23" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_6_0_0_pos" x="-18.23" y="0" z="(0)*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_6_0_0_rot" x="180.0*0" y="0" z="270" unit="deg"/>
+						<position name="ssdsensor_6_0_1_pos" x="18.23" y="0" z="(1-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(1-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_6_0_1_pos" x="18.23" y="0" z="(1)*ssdD0_thick+(0-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_6_0_1_rot" x="180.0*0" y="0" z="90" unit="deg"/>
+						<position name="ssdsensor_6_1_0_pos" x="0" y="-18.23" z="(0-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_6_1_0_pos" x="0" y="-18.23" z="(0)*ssdD0_thick+(1-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_6_1_0_rot" x="180.0*1" y="0" z="0" unit="deg"/>
+						<position name="ssdsensor_6_1_1_pos" x="0" y="18.23" z="(1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_6_1_1_pos" x="0" y="18.23" z="(1)*ssdD0_thick+(1-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_6_1_1_rot" x="180.0*1" y="0" z="180" unit="deg"/>
+						<position name="ssdsensor_6_2_0_pos" x="12.92" y="-12.92" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_6_2_0_pos" x="12.92" y="-12.92" z="(0)*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_6_2_0_rot" x="180.0*1" y="0" z="45" unit="deg"/>
+						<position name="ssdsensor_6_2_1_pos" x="-12.92" y="12.92" z="(1-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(1-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_6_2_1_pos" x="-12.92" y="12.92" z="(1)*ssdD0_thick+(0-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_6_2_1_rot" x="180.0*1" y="0" z="225" unit="deg"/>
 		<position name="ssdStation7_pos" x="0" y="0" z="ssdStation7_shift+ssdD0_thick-0.5*mount_thick"/>
-						<position name="ssdsensor_7_0_0_pos" x="-18.23" y="0" z="(0+0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0+0-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_7_0_0_pos" x="-18.23" y="0" z="(0+0)*ssdD0_thick+(0-0.5)*mount_thick+(0+0-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_7_0_0_rot" x="180.0*0" y="0" z="270" unit="deg"/>
-						<position name="ssdsensor_7_0_1_pos" x="18.23" y="0" z="(0+1-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0+1-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_7_0_1_pos" x="18.23" y="0" z="(0+1)*ssdD0_thick+(0-0.5)*mount_thick+(0+1-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_7_0_1_rot" x="180.0*0" y="0" z="90" unit="deg"/>
-						<position name="ssdsensor_7_1_0_pos" x="0" y="-18.23" z="(1+0-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1+0-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_7_1_0_pos" x="0" y="-18.23" z="(1+0)*ssdD0_thick+(1-0.5)*mount_thick+(1+0-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_7_1_0_rot" x="180.0*1" y="0" z="0" unit="deg"/>
-						<position name="ssdsensor_7_1_1_pos" x="0" y="19.23" z="(1+1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1+1-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_7_1_1_pos" x="0" y="19.23" z="(1+1)*ssdD0_thick+(1-0.5)*mount_thick+(1+1-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_7_1_1_rot" x="180.0*1" y="0" z="180" unit="deg"/>
+						<position name="ssdsensor_7_0_0_pos" x="-18.23" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_7_0_0_pos" x="-18.23" y="0" z="(0)*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_7_0_0_rot" x="180.0*0" y="0" z="270" unit="deg"/>
+						<position name="ssdsensor_7_0_1_pos" x="18.23" y="0" z="(1-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(1-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_7_0_1_pos" x="18.23" y="0" z="(1)*ssdD0_thick+(0-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_7_0_1_rot" x="180.0*0" y="0" z="90" unit="deg"/>
+						<position name="ssdsensor_7_1_0_pos" x="0" y="-18.23" z="(0-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(0-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_7_1_0_pos" x="0" y="-18.23" z="(0)*ssdD0_thick+(1-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_7_1_0_rot" x="180.0*1" y="0" z="0" unit="deg"/>
+						<position name="ssdsensor_7_1_1_pos" x="0" y="19.23" z="(1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_7_1_1_pos" x="0" y="19.23" z="(1)*ssdD0_thick+(1-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_7_1_1_rot" x="180.0*1" y="0" z="180" unit="deg"/>
 				<position name="ssdmount_local_0_0_pos" x="0" y="0" z="0"/>
 				<position name="ssdmount_0_0_pos" x="0" y="0" z="0+0.5*mount_thick"/>
 				<rotation name="ssdmount_0_0_rot" x="-0.44" y="-2.02" unit="deg"/>
@@ -242,8 +242,8 @@
 				<position name="ssdmount_7_0_pos" x="0" y="0" z="0+0.5*mount_thick"/>
 				<rotation name="ssdmount_7_0_rot" x="0.36" y="0.31" unit="deg"/>
 
-	 <position name="ssd_USMylarWindow_pos" x="0" y="0" z="Mylar_shift"/>
-	 <position name="ssd_DSMylarWindow_pos" x="0" y="0" z="-1.*Mylar_shift"/>
+	 <position name="ssd_USMylarWindow_pos" x="0" y="0" z="-1*Mylar_shift"/>
+	 <position name="ssd_DSMylarWindow_pos" x="0" y="0" z="Mylar_shift"/>
 
 
 		<position name="ssd_mount_u1_pos" x="70" y="0" z="0"/>
@@ -254,8 +254,8 @@
 		<position name="ssd_mount_u4_pos" x="80.1" y="-80.4"/>
 		<rotation name="ssd_mount_u4_rot" y="-90" z="135" unit="deg"/>
 
-	 <position name="ssd_mount_out_pos1" z="0.5*mount_thick+0.5*ssdD0_thick+0.5*ssd_bkpln_thick" unit="mm" />
-	 <position name="ssd_mount_out_pos2" z="-0.5*mount_thick-0.5*ssdD0_thick-0.5*ssd_bkpln_thick" unit="mm" />
+	 <position name="ssd_mount_out_pos1" z="0.5*mount_thick" unit="mm" />
+	 <position name="ssd_mount_out_pos2" z="-0.5*mount_thick" unit="mm" />
 
 	 <quantity name="ssdStationrotateLength" value="50" unit="mm" />
 	 <quantity name="ssdStationrotateWidth" value="300" unit="mm" />
@@ -2160,7 +2160,7 @@ values="202.14067278287462 12.054573032169143
 		<second ref="ssd_mount_box2"/>
 	 </subtraction>
 
-	 <box name="ssd_mount_out_box" x="1.2*mount_width" y="1.2*mount_width" z="ssdD0_thick+ssd_bkpln_thick" />
+	 <box name="ssd_mount_out_box" x="1.2*mount_width" y="1.2*mount_width" z="2*ssdD0_thick+2*ssd_bkpln_thick" />
 	 <union name="ssd_mount_enclosure_u1">
 	   <first ref="ssd_mount_box"/>
 		<second ref="ssd_mount_out_box"/>

--- a/Geometry/gdml/phase1c/generate_gdml.pl
+++ b/Geometry/gdml/phase1c/generate_gdml.pl
@@ -314,23 +314,14 @@ EOF
 				if($j == 2){
 					$imount++;
 				}
+				$l=$j%2;
 				for($k = 0; $k < $SSD_par[ $SSD_station[ $i ] ]; ++$k){
-					if($j < 2){
-						print DEF <<EOF;
-						<position name="ssdsensor_@{[ $i ]}_@{[ $j ]}_@{[ $k ]}_pos" x="$SSD_shift[ $isensor][0]" y="$SSD_shift[ $isensor][1]" z="($j+$k-0.5)*ssdD0_thick+($j-0.5)*mount_thick+($j+$k-1)*ssd_bkpln_thick"/>
-						<position name="ssd_bkpln_@{[ $i ]}_@{[ $j ]}_@{[ $k ]}_pos" x="$SSD_shift[ $isensor][0]" y="$SSD_shift[ $isensor][1]" z="($j+$k)*ssdD0_thick+($j-0.5)*mount_thick+($j+$k-0.5)*ssd_bkpln_thick"/>
-					 	<rotation name="ssdsensor_@{[ $i ]}_@{[ $j ]}_@{[ $k ]}_rot" x="180.0*@{[ $SSD_side[$isensor] ]}" y="0" z="@{[ $SSD_angle[$isensor] ]}" unit="deg"/>
+					print DEF <<EOF;
+						<position name="ssdsensor_@{[ $i ]}_@{[ $j ]}_@{[ $k ]}_pos" x="$SSD_shift[ $isensor][0]" y="$SSD_shift[ $isensor][1]" z="($k-0.5)*ssdD0_thick+($l-0.5)*mount_thick+($k-1)*ssd_bkpln_thick"/>
+						<position name="ssd_bkpln_@{[ $i ]}_@{[ $j ]}_@{[ $k ]}_pos" x="$SSD_shift[ $isensor][0]" y="$SSD_shift[ $isensor][1]" z="($k)*ssdD0_thick+($l-0.5)*mount_thick+($k-0.5)*ssd_bkpln_thick"/>
+						<rotation name="ssdsensor_@{[ $i ]}_@{[ $j ]}_@{[ $k ]}_rot" x="180.0*@{[ $SSD_side[$isensor] ]}" y="0" z="@{[ $SSD_angle[$isensor] ]}" unit="deg"/>
 EOF
-						$isensor++;
-					}
-					else{
-						 print DEF <<EOF;
-                   <position name="ssdsensor_@{[ $i ]}_@{[ $j ]}_@{[ $k ]}_pos" x="$SSD_shift[ $isensor][0]" y="$SSD_shift[ $isensor][1]" z="($k+0.5)*ssdD0_thick+ssd_bkpln_thick+0.5*mount_thick"/>
-						<position name="ssd_bkpln_@{[ $i ]}_@{[ $j ]}_@{[ $k ]}_pos" x="$SSD_shift[ $isensor][0]" y="$SSD_shift[ $isensor][1]" z="($k+0.5)*ssd_bkpln_thick+0.5*mount_thick"/>
-					 	<rotation name="ssdsensor_@{[ $i ]}_@{[ $j ]}_@{[ $k ]}_rot" x="180.0*@{[ $SSD_side[$isensor] ]}" y="0" z="@{[ $SSD_angle[$isensor] ]}" unit="deg"/>
-EOF
-						$isensor++;
-					}
+					$isensor++;
 				}
 			}
 			$imount++;
@@ -349,8 +340,8 @@ EOF
 
 		print DEF <<EOF;
 
-	 <position name="ssd_USMylarWindow_pos" x="0" y="0" z="Mylar_shift"/>
-	 <position name="ssd_DSMylarWindow_pos" x="0" y="0" z="-1.*Mylar_shift"/>
+	 <position name="ssd_USMylarWindow_pos" x="0" y="0" z="-1*Mylar_shift"/>
+	 <position name="ssd_DSMylarWindow_pos" x="0" y="0" z="Mylar_shift"/>
 
 
 		<position name="ssd_mount_u1_pos" x="70" y="0" z="0"/>
@@ -361,8 +352,8 @@ EOF
 		<position name="ssd_mount_u4_pos" x="80.1" y="-80.4"/>
 		<rotation name="ssd_mount_u4_rot" y="-90" z="135" unit="deg"/>
 
-	 <position name="ssd_mount_out_pos1" z="0.5*mount_thick+0.5*ssdD0_thick+0.5*ssd_bkpln_thick" unit="mm" />
-	 <position name="ssd_mount_out_pos2" z="-0.5*mount_thick-0.5*ssdD0_thick-0.5*ssd_bkpln_thick" unit="mm" />
+	 <position name="ssd_mount_out_pos1" z="0.5*mount_thick" unit="mm" />
+	 <position name="ssd_mount_out_pos2" z="-0.5*mount_thick" unit="mm" />
 
 	 <quantity name="ssdStationrotateLength" value="50" unit="mm" />
 	 <quantity name="ssdStationrotateWidth" value="300" unit="mm" />
@@ -705,7 +696,7 @@ EOF
 		<second ref="ssd_mount_box2"/>
 	 </subtraction>
 
-	 <box name="ssd_mount_out_box" x="1.2*mount_width" y="1.2*mount_width" z="ssdD0_thick+ssd_bkpln_thick" />
+	 <box name="ssd_mount_out_box" x="1.2*mount_width" y="1.2*mount_width" z="2*ssdD0_thick+2*ssd_bkpln_thick" />
 	 <union name="ssd_mount_enclosure_u1">
 	   <first ref="ssd_mount_box"/>
 		<second ref="ssd_mount_out_box"/>


### PR DESCRIPTION
In PR 149, I was checking the geometry with the default gdml file, which is not the newly produced one, since we changed the naming convention (adding TargetName to the gdml filename).  Thanks @lackey32 for pointing this out in slack.
I therefore did not notice a conflict that would cause an MC exception. It's a volume overlap in SSD and is fixed in this PR.