### PR TITLE
Add dot to filename so it plays well with CAFMaker file naming.

### DIFF
--- a/Digitization/digitization_job.fcl
+++ b/Digitization/digitization_job.fcl
@@ -20,7 +20,7 @@ outputs:
  out1:
   {
    module_type: RootOutput
-   fileName:    "%ifb_dig.root"
+   fileName:    "%ifb.dig.root"
    fastCloning: false
    
   }


### PR DESCRIPTION
The default name for the digitization job (creates MC file equivalent to the artdaqs for data) only had one dot, which made CAFMaker unhappy with the new filenaming logic I added in. The dots make it easier to separate out file tiers anyways.