### PR TITLE
Bugfix/lackey32 cafname and const view

### DIFF
--- a/CAFMaker/CAFMaker_module.cc
+++ b/CAFMaker/CAFMaker_module.cc
@@ -135,8 +135,8 @@ namespace caf {
       char *temp = new char[fb.fileName().size() + 1];
       std::strcpy(temp, fb.fileName().c_str());
       fCAFFilename = basename(temp);
-      // Expects filename to end with .XXXX e.g., '.root'
-      const size_t dotpos = fCAFFilename.find_last_of('.',fCAFFilename.length()-6);
+      // find last . in filename, drop everything after it and append .caf.root
+      const size_t dotpos = fCAFFilename.find_last_of('.');
       assert(dotpos != std::string::npos);  // Must have a dot, surely?
       fCAFFilename.resize(dotpos);
       fCAFFilename += fParams.FileExtension();

--- a/Geometry/Geometry.h
+++ b/Geometry/Geometry.h
@@ -118,7 +118,7 @@ namespace emph {
 
       const Detector* SSD(int i) const { return &fSSD[i];}
       int  NSSDs() const { return int(fSSD.size()); }
-      sensorView View() { if (fSSD.empty()) return INIT; return fSSD[0].View(); }
+      sensorView View() const { if (fSSD.empty()) return INIT; return fSSD[0].View(); }
 
       void AddSSD(Detector ssd) { fSSD.push_back(ssd); }
 


### PR DESCRIPTION
CAF file naming will now only drop characters after the last dot.
Added const into the plane View() function.