### PR TITLE
Geometry Memory Bug Fix

### DIFF
--- a/Geometry/Geometry.cxx
+++ b/Geometry/Geometry.cxx
@@ -210,7 +210,7 @@ Plane::Plane() :
       fGeoManager->LockDefaultUnits(0);
       fGeoManager->SetDefaultUnits(TGeoManager::EDefaultUnits::kG4Units);
       fGeoManager->LockDefaultUnits(1);
-      fGeoManager->Import(fGDMLFile.c_str());
+      fGeoManager = fGeoManager->Import(fGDMLFile.c_str());
 
       //      fGeoManager->Import(fname.c_str());
       /*


### PR DESCRIPTION
Fixed a memory management bug in the geometry service.  We have to update our pointer to the TGeoManager every time TGeoManager::Import() is called.  I checked that the geometry unit test doesn't change for run 1234.  Requests for more testing and/or more changes are welcome!