### PR TITLE
Feature/aolivier no mc particle bug fix

### DIFF
--- a/CAFMaker/SRTruthFiller.cxx
+++ b/CAFMaker/SRTruthFiller.cxx
@@ -24,7 +24,7 @@ namespace caf
       std::vector<sim::Particle> particles;
       if(!pcal.failedToGet()){particles = *pcal;}
       
-        
+      assert(!particles.empty() && "Got an event with no primary particle.  Rebuild your code with develop and check your generator job!");        
       auto beam_temp = SRParticle(particles[0]);// grab the first beam particle, do an upcast and then a downcast from
       SRTrueParticle beam = SRTrueParticle(beam_temp);// sim::Particle to caf::SRParticle and then from caf::SRParticle to caf:: SRTP
       /*

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -4,7 +4,7 @@
          "cacheVariables" : {
             "CMAKE_BUILD_TYPE" : {
                "type" : "STRING",
-               "value" : "Debug"
+               "value" : "RelWithDebInfo"
             },
             "CMAKE_CXX_EXTENSIONS" : {
                "type" : "BOOL",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -4,7 +4,7 @@
          "cacheVariables" : {
             "CMAKE_BUILD_TYPE" : {
                "type" : "STRING",
-               "value" : "RelWithDebInfo"
+               "value" : "Debug"
             },
             "CMAKE_CXX_EXTENSIONS" : {
                "type" : "BOOL",

--- a/G4EMPH/G4Gen_module.cc
+++ b/G4EMPH/G4Gen_module.cc
@@ -142,7 +142,7 @@ namespace emph {
     evt.getByLabel(fGeneratorLabel, beam);
     
     // make sure there is only one beam particle
-    assert(beam.size() == 1);
+    assert(beam->size() == 1);
     simb::MCParticle b = beam->at(0);
     //
     // now create MCTruth

--- a/G4EMPH/ParticleListAction.cxx
+++ b/G4EMPH/ParticleListAction.cxx
@@ -142,12 +142,6 @@ namespace emph {
 	const G4double energy = track->GetKineticEnergy();		// get the kinetic energy
 //		std::cerr << "fEnergyCut = " << fEnergyCut << std::endl;
 
-	if (energy < fEnergyCut){   			// if the particle is below the energy cut, we should not add it to the list, and skip it
-//	                  std::cerr << "Particle is below energy cut... halt tracking..." << std::endl;
-                fParticle = 0;          		// we do not want to step this particle, so setting fParticle to 0 is ?needed?
-                return;
-        }
-
 	const G4int trackID = track->GetTrackID() + fTrackIDOffset;	// get the track ID for this particle
 	fCurrentTrackID = trackID;					// set the fCurrentTrackID to the actual, real, current particle
 	// size_t mcTruthIndex = 0;					// set the index of this particle in the truth record to 0
@@ -156,6 +150,13 @@ namespace emph {
 	const G4int                      pdg = partdef->GetPDGEncoding();       // get the particle type
 	const G4DynamicParticle*         dp = track->GetDynamicParticle();      //
 	const G4PrimaryParticle*         pp = dp->GetPrimaryParticle();         // its a surprise tool that'll help us later...
+
+        if (energy < fEnergyCut){                       // if the particle is below the energy cut, we should not add it to the list, and skip it
+          if(pp) throw cet::exception("ParticleListAction") << "Primary particle with energy " << energy << " MeV was below ParticleListAction::fEnergyCut = " << fEnergyCut << " MeV and would have been thrown out.  But this crashes CAFMaker!  Your generator .fcl has a bug!";
+//                        std::cerr << "Particle is below energy cut... halt tracking..." << std::endl;
+                fParticle = 0;                          // we do not want to step this particle, so setting fParticle to 0 is ?needed?
+                return;
+        }
     
 	//std::cerr << "%%%%% New Particle: trackID = " << trackID << " PDG: " << pdg <<" %%%%%" << std::endl;	
 	

--- a/RecoBase/Track.cxx
+++ b/RecoBase/Track.cxx
@@ -38,7 +38,7 @@ namespace rb {
 
   void Track::Add(const rb::TrackSegment& ts)
   {
-    assert(_clust.empyt() && _spcpt.empty());
+    assert(_clust.empty() && _spcpt.empty());
     _sgmnt.push_back(rb::TrackSegment(ts));
   }
 
@@ -46,7 +46,7 @@ namespace rb {
 
   void Track::Add(const rb::SpacePoint& sp)
   {
-    assert(_clust.empyt() && _sgmnt.empty());
+    assert(_clust.empty() && _sgmnt.empty());
     _spcpt.push_back(rb::SpacePoint(sp));
   }
 
@@ -92,7 +92,7 @@ namespace rb {
     double x = -9999.;
     double y = -9999.;
 
-    assert(_pos.size>= 2);
+    assert(_pos.size()>= 2);
 
     if (z >= _vtx[2]) {
       size_t i=0; 

--- a/SSDReco/SSDHotChannelList.cxx
+++ b/SSDReco/SSDHotChannelList.cxx
@@ -136,9 +136,9 @@ namespace emph {
 	  if (diff/sigFinal < signif) continue; // O.K.  
 	  fHotChannels.push_back(k+3);
 	} // last channel, who knows.. 
+        std::cerr << " SSDHotChannelList::tallyIt, for Station " << fStation << " " << fSensor << " num Hot " << fHotChannels.size() << std::endl;
+        std::cerr << " And enough work, quit for now.. " << std::endl;
         return static_cast<int>(fHotChannels.size());
-	std::cerr << " SSDHotChannelList::tallyIt, for Station " << fStation << " " << fSensor << " num Hot " << fHotChannels.size() << std::endl; 
-	std::cerr << " And enough work, quit for now.. " << std::endl;
       }
       
       

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -320,7 +320,7 @@ c7:debug   c7:debug   c7:debug     -               -               c7:debug    c
 c7:prof	   c7:prof    c7:prof      -               -               c7:prof     c7:p392:debug    c7:prof      c7:prof
 e19:debug  e19:debug  e19:debug    e19:debug:s111  e19:debug:s111  e19:debug   e19:p392:debug   e19:debug    e19:p392:debug
 e19:prof   e19:prof   e19:prof     e19:prof:s111   e19:prof:s111   e19:prof    e19:p392:prof    e19:prof     e19:p392:prof
-e20:debug  e20:debug  e20:debug    e20:debug:s118  e20:prof:s118   e20:debug   e20:p3913:debug  e20:debug    e20:p3913:debug  py3913
+e20:debug  e20:debug  e20:debug    e20:debug:s118  e20:debug:s118   e20:debug   e20:p3913:debug  e20:debug    e20:p3913:debug  py3913
 e20:prof   e20:prof   e20:prof     e20:prof:s118   e20:prof:s118   e20:prof    e20:p3913:prof   e20:prof     e20:p3913:prof   py3913
 end_qualifier_list
 ####################################


### PR DESCRIPTION
Fix bug where MC generation job produces Events with no sim::Particles in them.  ParticleListAction was throwing out the primary particle when it has energy below our general GEANT cutoff.  It now throws an exception when this happens telling the user to fix their generator .fcl file.  This was crashing a student's CAFMaker jobs before I fixed it.  I also added an assert() in CAFMaker when there's no primary particle to make bugs like this one easier to debug in the future.

I also rolled in some bug fixes that make emphaticsoft compile in debug mode as well as prof mode.  Some of our assert()s were hiding code that doesn't actually compile but was easy to fix.  Note that I also changed ups/product_deps in one place because a debug build was trying to set up the prof flavor of artdaq against the debug flavor of other products.  I checked that everything builds in both modes before committing.