### PR TITLE
Quick fix for the build

### DIFF
--- a/MagneticField/CMakeLists.txt
+++ b/MagneticField/CMakeLists.txt
@@ -25,5 +25,4 @@ install_source()
 install_fhicl()
 
 add_subdirectory(service)
-add_subdirectory(field_map_tools)
 add_subdirectory(test)


### PR DESCRIPTION
The build hasn't been working because it was looking for a non-existent subdirectory, `MagneticFiled/field_map_tools`.