### PR TITLE
Measured field maps

### DIFF
--- a/Geometry/Geometry.cxx
+++ b/Geometry/Geometry.cxx
@@ -138,8 +138,10 @@ Plane::Plane() :
       fTarget = 0;
       fGeoManager = 0;
       fSSDSensorMap.clear();
-      fMagnetUSZPos = -1e6;
-      fMagnetDSZPos = -1e6;
+      for (int i=0; i<3; ++i) {
+	fMagnetUSPos[i] = -1e6;
+	fMagnetDSPos[i] = -1e6;
+      }
       fTargetUSZPos = -1e7;
       fTargetDSZPos = -1e7;
       fGeoManager = new TGeoManager("EMPHGeometry","EMPHATIC Geometry Manager");
@@ -369,21 +371,24 @@ Plane::Plane() :
 			mf::LogWarning("LoadNewGeometry") 
 				<< " magnet not found in gdml. \n"
 				<< "check your spelling. \n";
-			fMagnetUSZPos = -1e6;
-			fMagnetDSZPos = -1e6;
-
 			return;
 		}
 
       TGeoVolume* magnet_v = (TGeoVolume*)magnet_n->GetVolume();
       TGeoBBox* magnet_box = (TGeoBBox*)magnet_v->GetShape();
 
+      double xcenter = magnet_n->GetMatrix()->GetTranslation()[0];
+      double ycenter = magnet_n->GetMatrix()->GetTranslation()[1];
       double zcenter = magnet_n->GetMatrix()->GetTranslation()[2];
       double dz = magnet_box->GetDZ();
 
-      fMagnetUSZPos = zcenter-dz;
-      fMagnetDSZPos = zcenter+dz;
-		fMagnetLoad = true;
+      fMagnetUSPos[2] = zcenter-dz;
+      fMagnetDSPos[2] = zcenter+dz;
+      fMagnetUSPos[0] = xcenter;
+      fMagnetDSPos[0] = xcenter;
+      fMagnetUSPos[1] = ycenter;
+      fMagnetDSPos[1] = ycenter;
+      fMagnetLoad = true;
 
     }
 

--- a/Geometry/Geometry.h
+++ b/Geometry/Geometry.h
@@ -210,8 +210,12 @@ namespace emph {
       double TargetUSZPos() const {return fTargetUSZPos; }
       double TargetDSZPos() const {return fTargetDSZPos; }
 
-      double MagnetUSZPos() const {return fMagnetUSZPos; }
-      double MagnetDSZPos() const {return fMagnetDSZPos; }
+      double MagnetUSZPos() const {return fMagnetUSPos[2]; }
+      double MagnetDSZPos() const {return fMagnetDSPos[2]; }
+      double MagnetUSXPos() const {return fMagnetUSPos[0]; }
+      double MagnetDSXPos() const {return fMagnetDSPos[0]; }
+      double MagnetUSYPos() const {return fMagnetUSPos[1]; }
+      double MagnetDSYPos() const {return fMagnetDSPos[1]; }
       bool MagnetLoad() const {return fMagnetLoad; }
 
       double DetectorUSZPos(int i) const {return fDetectorUSZPos[i]; }
@@ -260,8 +264,8 @@ namespace emph {
       double fWorldWidth;
       double fWorldHeight;
       double fWorldLength;
-      double fMagnetUSZPos;
-      double fMagnetDSZPos;
+      double fMagnetUSPos[3];
+      double fMagnetDSPos[3];
       double fTargetUSZPos;
       double fTargetDSZPos;
       bool   fMagnetLoad;

--- a/MagneticField/MagneticField.cxx
+++ b/MagneticField/MagneticField.cxx
@@ -50,16 +50,14 @@ namespace emph {
 
   void MagneticField::AlignWithGeom() {
     // by convention, the field map's local coordinate system has it's orgin at the center of the upstream face of the magnet
+    fG4ZipTrackOffset[2] = 0.;
+
     art::ServiceHandle<emph::geo::GeometryService> geomService;
     const emph::geo::Geometry* geo = geomService->Geo();
 
-    fG4ZipTrackOffset[2] = -geo->MagnetUSZPos();
-
-    /*
-      Need to add some functionality to the Geometry class to provide these
-      fG4ZipTrackOffset[0] = -geo->MagnetUSXPos();
-      fG4ZipTrackOffset[1] = -geo->MagnetUSYPos();
-    */
+    fG4ZipTrackOffset[2] = geo->MagnetUSZPos();
+    fG4ZipTrackOffset[0] = geo->MagnetUSXPos();
+    fG4ZipTrackOffset[1] = geo->MagnetUSYPos();
 
     if (fVerbosity)
       std::cerr << " MagneticField::AlignWithGeom G4ZipTrack Z Offset set to " << fG4ZipTrackOffset[2] << std::endl;
@@ -324,14 +322,16 @@ namespace emph {
     if (fFieldFileName.empty())
       abort();
     TFile* fin = new TFile(fFieldFileName.c_str());
-    TH3F* hT = (TH3F*)fin->Get("hBx");
-    fBx3DHisto = (TH3F*)hT->Clone("hBx3DHist");
-    hT = (TH3F*)fin->Get("hBy");
-    fBy3DHisto = (TH3F*)hT->Clone("hBy3DHist");
-    hT = (TH3F*)fin->Get("hBz");
-    fBz3DHisto = (TH3F*)hT->Clone("hBz3DHist");
+    fBx3DHisto = (TH3F*)fin->Get("hBx");
+    fBx3DHisto->SetDirectory(0);
+    fBy3DHisto = (TH3F*)fin->Get("hBy");
+    fBy3DHisto->SetDirectory(0);
+    fBz3DHisto = (TH3F*)fin->Get("hBz");
+    fBz3DHisto->SetDirectory(0);
+
     fin->Close();
     fFieldLoaded = true;
+    this->AlignWithGeom();
   }
 
   //----------------------------------------------------------------------
@@ -347,11 +347,32 @@ namespace emph {
       }
       this->LoadRootHistos();
     }
-    
-    B[0] = 1.e5* (fBx3DHisto->Interpolate(x[0],x[1],x[2]));
-    B[1] = 1.e5* (fBy3DHisto->Interpolate(x[0],x[1],x[2]));
-    B[2] = 1.e5* (fBz3DHisto->Interpolate(x[0],x[1],x[2]));
 
+    //    std::cout << "***** (x,y,z) = (" << x[0] << "," << x[1] << "," << x[2]
+    //	      << ")" << std::endl;
+
+    double xbw = fBy3DHisto->GetXaxis()->GetBinWidth(1);
+    double ybw = fBy3DHisto->GetYaxis()->GetBinWidth(1);
+    double zbw = fBy3DHisto->GetZaxis()->GetBinWidth(1);
+
+    if (x[0] > (fBy3DHisto->GetXaxis()->GetXmin()+xbw) &&
+	x[0] < (fBy3DHisto->GetXaxis()->GetXmax()-xbw) &&
+	x[1] > (fBy3DHisto->GetYaxis()->GetXmin()+ybw) &&
+	x[1] < (fBy3DHisto->GetYaxis()->GetXmax()-ybw) &&
+	x[2] > (fBy3DHisto->GetZaxis()->GetXmin()+zbw) &&
+	x[2] < (fBy3DHisto->GetZaxis()->GetXmax()-zbw)) {
+      
+      //      std::cout << "***** (x,y,z) = (" << x[0] << "," << x[1] << "," << x[2]
+      //		<< ")" << std::endl;
+      
+      // factor of 10 to convert Tesla to kGauss
+      B[0] = 10. * fBx3DHisto->Interpolate(x[0],x[1],x[2]);
+      B[1] = 10. * fBy3DHisto->Interpolate(x[0],x[1],x[2]);
+      B[2] = 10. * fBz3DHisto->Interpolate(x[0],x[1],x[2]);
+    }
+    else {
+      B[0] = B[1] = B[2] = 0.;
+    }
   }
 
   //----------------------------------------------------------------------
@@ -593,10 +614,14 @@ namespace emph {
   void MagneticField::GetFieldValue(const double x[3], double* B) 
   {
     double xAligned[3];
-    for (size_t k=0; k != 3; k++) xAligned[k] = x[k] + fG4ZipTrackOffset[k];
-    double BInKg[3];
-    const double rR = std::sqrt(x[0]*x[0] + x[1]*x[1]);
+    for (size_t k=0; k != 3; k++) xAligned[k] = x[k] - fG4ZipTrackOffset[k];
     this->Field(xAligned, B);
+    //    if (fabs(B[1])>0.) { 
+    //     std::cout << "at (" << x[0] << "," << x[1] << "," << x[2] << "), B(" 
+    //		<< xAligned[0] << "," << xAligned[1] << "," 
+    //		<< xAligned[2] << ") = (" << B[0] << "," << B[1] << "," << B[2]
+    //		<< ")" << std::endl;
+    //    }
   }
 
   //----------------------------------------------------------------------

--- a/MagneticField/MagneticField.fcl
+++ b/MagneticField/MagneticField.fcl
@@ -2,9 +2,9 @@ BEGIN_PROLOG
 
 standard_magfield:
 {
-  FieldFileName: "/cvmfs/emphatic.opensciencegrid.org/magFieldMaps/mfMap_TRIUMF_COMSOL_2020_01_01_v2.txt"
-
-  StoreMapAsStlVector: true  
+  FieldFileName: "/cvmfs/emphatic.opensciencegrid.org/magFieldMaps/Phase1Fitted1mmMap.root"
+  UsingRootHistos: true
+  StoreMapAsStlVector: false
   Verbosity: 0
 }
 

--- a/MagneticField/MagneticField.h
+++ b/MagneticField/MagneticField.h
@@ -13,6 +13,8 @@
 #include <vector>
 #include <string>
 
+#include "TH3F.h"
+
 class G4FieldManager;
 
 namespace emph {
@@ -32,6 +34,7 @@ namespace emph {
     void GetFieldValue(const double Point[3], double* Bfield); // units are mm, return values in kilogauss
     void SetFieldFileName(std::string fileName) { fFieldFileName = fileName; }
     void SetVerbosity(int v) { fVerbosity = v; }
+    void SetUsingRootHistos(bool flag=false) { fUsingRootHistos=flag; }
 
   private:
     std::string fFieldFileName;
@@ -47,18 +50,26 @@ namespace emph {
     double fStepX, fStepY, fStepZ; 
     int fInterpolateOption;
     int fVerbosity;
+    bool  fUsingRootHistos;
+    TH3F* fBx3DHisto;
+    TH3F* fBy3DHisto;
+    TH3F* fBz3DHisto;
 
   public: 
     void SetUseStlVector(bool useVec) { fStorageIsStlVector = useVec; }
     inline void setInterpolatingOption(int iOpt) { fInterpolateOption = iOpt; } // iOpt = 0 => 3D radial average , 1 linearized along axes of the 3D grid. 
+    
     void Integrate(int iOpt, int charge, double stepAlongZ,  
 		   std::vector<double> &start, std::vector<double> &end); 
     //    inline void setUseOnlyTheCentralPart(bool  t=true) {  fUseOnlyCentralPart = t; }    
   private:
     void uploadFromTextFile();
+    void LoadRootHistos();
     void AlignWithGeom();
     void CalcFieldFromVector(const double Point[3], double* Bfield);
     void CalcFieldFromMap(const double Point[3], double* Bfield);
+    void CalcFieldFromRootHistos(const double Point[3], double* Bfield);
+
     inline size_t indexForVector(double *xyz) const {
       double *ptr = xyz; 
       // floor seems to fail if close to real boundary, so add a tiny offset

--- a/MagneticField/service/MagneticField_service.cc
+++ b/MagneticField/service/MagneticField_service.cc
@@ -22,6 +22,7 @@ namespace emph
     fMagneticField = new emph::MagneticField();
 
     fMagneticField->SetFieldFileName(pset.get< std::string >("FieldFileName"));
+    fMagneticField->SetUsingRootHistos(pset.get< bool >("UsingRootHistos"));
     fMagneticField->SetUseStlVector(pset.get< bool >("StoreMapAsStlVector"));
     fMagneticField->SetVerbosity(pset.get<int>("Verbosity"));
 

--- a/RawData/TRB3RawDigit.cxx
+++ b/RawData/TRB3RawDigit.cxx
@@ -16,7 +16,7 @@ namespace emph {
       tdc_header_word(0),
       tdc_epoch_word(0),
       tdc_measurement_word(0),
-      event_index(0), fragmentTimestamp(0), fdetChan(-1),  fHitTime(0), fIsNoise(false)
+      event_index(0), fragmentTimestamp(0), fdetChan(-1),  fIsNoise(false), fHitTime(0) 
     {
     }
    


### PR DESCRIPTION
Updated MagneticField code to use Prachi's fitted magnetic field, which is a simple 1mmx1mmx1mm grid of (Bx,By,Bz).  For this we use a simple Root TH3F for each component of the field vector, and make use of the TH3 triilinear interpolation.  Validated both visually (event display) and Robert Chirco checking the bend angle of a 4 GeV particle.