### PR TITLE
Bugfix/lackey32/module label data and sim

### DIFF
--- a/ARICHReco/MakeArichCluster.fcl
+++ b/ARICHReco/MakeArichCluster.fcl
@@ -3,7 +3,7 @@ BEGIN_PROLOG
 standard_arich_cluster:
 {
   module_type: 	  MakeArichCluster 
-  LabelHits:      "rawARICH:ARICH"
+  LabelHits:      "raw:ARICH"
   LabelTracks:    "geantgen"			#using sim::Tracks untill got rb::Tracks 
   FillTree:       true
   FitCircle:      false

--- a/CAFMaker/CAFMaker.fcl
+++ b/CAFMaker/CAFMaker.fcl
@@ -3,7 +3,7 @@ BEGIN_PROLOG
 #   This file defines the configuration for the job module "CAFMaker"
 standard_cafmaker:{
     module_type:   CAFMaker
-    CAFFilename:   "out.caf.root" # Provide a string to override the automatic filename
+    CAFFilename:   "" # Provide a string to override the automatic filename
     FileExtension: ".caf.root"
 
     ARingLabel:        "arichreco"
@@ -14,8 +14,7 @@ standard_cafmaker:{
     SpacePointLabel:   "maketracksegments"
     SSDClustLabel:     "clust"
     SSDHitLabel:       "geantgen" #dah
-    #SSDRawLabel:       "raw:SSD"
-    SSDRawLabel:       "rawSSD:SSD"
+    SSDRawLabel:       "raw:SSD"
     TrackLabel:        "makesingletracks"
     TrackSegmentLabel: "maketracksegments"
 

--- a/CAFMaker/prod_reco_caf_job.fcl
+++ b/CAFMaker/prod_reco_caf_job.fcl
@@ -4,6 +4,7 @@
 
 #include "FillDataQuality.fcl"
 #include "SpillInfo.fcl"
+#include "MakeArichCluster.fcl"
 #include "ARICHReco.fcl"
 #include "MakeSSDClusters.fcl"
 #include "ADCReco.fcl"
@@ -37,21 +38,15 @@ physics:
 {
   producers:
   {
-    //spillinfo: @local::standard_spillinfo
-    //arichreco:  @local::standard_arichreco
-    //clust:  @local::standard_ssdclust
-    //adcreco:    @local::standard_adcreco
-    //backovreco: @local::standard_backovhitreco
-    //gasckovreco: @local::standard_gasckovhitreco
-    //cafmaker:   @local::standard_cafmaker
-    dataqual:         @local::standard_dataqual
-    spillinfo:        @local::standard_spillinfo
-    arichreco:        @local::standard_arichreco
-    clust:            @local::standard_ssdclust
-    adcreco:          @local::standard_adcreco
-    backovreco:       @local::standard_backovhitreco
-    gasckovreco:      @local::standard_gasckovhitreco
-    cafmaker:         @local::standard_cafmaker
+    dataqual:     @local::standard_dataqual
+    spillinfo:    @local::standard_spillinfo
+    arichcluster: @local::standard_arich_cluster
+    arichreco:    @local::standard_arichreco
+    clust:        @local::standard_ssdclust
+    adcreco:      @local::standard_adcreco
+    backovreco:   @local::standard_backovhitreco
+    gasckovreco:  @local::standard_gasckovhitreco
+    cafmaker:     @local::standard_cafmaker
 
     maketracksegments: @local::standard_maketracksegments
     makesingletracks: @local::standard_makesingletracks
@@ -61,9 +56,9 @@ physics:
   analyzers:{}
 
   makecaf:   [
-               dataqual, spillinfo, arichreco, clust,
-               maketracksegments, makesingletracks, singletrackalignment, adcreco, backovreco, gasckovreco,
-               #adcreco, backovreco, gasckovreco,
+               dataqual, spillinfo, arichcluster, arichreco, clust,
+               maketracksegments, makesingletracks, singletrackalignment,
+               adcreco, backovreco, gasckovreco,
                cafmaker
              ]
 

--- a/DataQuality/FillDataQuality.fcl
+++ b/DataQuality/FillDataQuality.fcl
@@ -4,7 +4,7 @@ standard_dataqual:
 {
   module_type:  FillDataQuality
   TriggerLabel: "raw:Trigger"
-  SSDDataLabel: "rawSSD:SSD"
+  SSDDataLabel: "raw:SSD"
 }
 
 END_PROLOG

--- a/Digitization/CMakeLists.txt
+++ b/Digitization/CMakeLists.txt
@@ -61,23 +61,10 @@ cet_build_plugin(ARICHDigitizer art::module
 
 cet_build_plugin(RelabelRawDigitModules art::module
   LIBRARIES PRIVATE
-        SimulationBase
-        Simulation
-        G4Base
-        Geometry
         RawData
-        ChannelMap
-        ChannelMapService_service
-        DetGeoMap
-        DetGeoMapService_service
-        art_root_io::TFileService_service
         art::Framework_Core
-	art::Framework_Principal
-	art_root_io::tfile_support ROOT::Core        
-	art::Framework_Services_Registry
         art::Persistency_Common
         messagefacility::MF_MessageLogger
-	art::Framework_IO_ProductMix
 )
 
 install_source()

--- a/Digitization/CMakeLists.txt
+++ b/Digitization/CMakeLists.txt
@@ -59,6 +59,26 @@ cet_build_plugin(ARICHDigitizer art::module
         messagefacility::MF_MessageLogger
 )
 
+cet_build_plugin(RelabelRawDigitModules art::module
+  LIBRARIES PRIVATE
+        SimulationBase
+        Simulation
+        G4Base
+        Geometry
+        RawData
+        ChannelMap
+        ChannelMapService_service
+        DetGeoMap
+        DetGeoMapService_service
+        art_root_io::TFileService_service
+        art::Framework_Core
+	art::Framework_Principal
+	art_root_io::tfile_support ROOT::Core        
+	art::Framework_Services_Registry
+        art::Persistency_Common
+        messagefacility::MF_MessageLogger
+	art::Framework_IO_ProductMix
+)
 
 install_source()
 install_headers()

--- a/Digitization/RelabelRawDigitModules.fcl
+++ b/Digitization/RelabelRawDigitModules.fcl
@@ -1,0 +1,12 @@
+BEGIN_PROLOG
+
+standard_digitrelabel:
+{
+  module_type:        "RelabelRawDigitModules"
+  RawDigitLabelARICH: "rawARICH:ARICH" 
+  RawDigitLabelSSD:   "rawSSD:SSD"
+  InstanceLabelARICH: "ARICH"
+  InstanceLabelSSD:   "SSD"
+}
+
+END_PROLOG

--- a/Digitization/RelabelRawDigitModules_module.cc
+++ b/Digitization/RelabelRawDigitModules_module.cc
@@ -58,22 +58,15 @@ namespace emph {
     art::Handle< std::vector<rawdata::SSDRawDigit> > ssdHandle;
     evt.getByLabel(fRawDigitLabelSSD, ssdHandle);
 
-    // auto ssdHandle = evt.getHandle<std::vector<emph::rawdata::SSDRawDigit> >(fRawDigitLabelSSD);
     for (unsigned int i = 0; i<ssdHandle->size(); ++i) {
       rawdata::SSDRawDigit digit ( (*ssdHandle)[i]);
       ssdDigs->push_back(digit);
     }
-    //if (!ssdHandle.failedToGet()) ssdDigs = *ssdHandle;
 
     for (unsigned int i = 0; i<arichHandle->size() ; ++i) {
       rawdata::TRB3RawDigit digit ( (*arichHandle)[i]);
       arichDigs->push_back(digit);
     }
-
-    // for (size_t i = 0; i< ssdHandle->size(); ++i) {
-    //   art::Ptr<emph::rawdata::SSDRawDigit> digit(ssdHandle,i);
-    //   ssdDigs->push_back(digit);
-    // }
 
     evt.put(std::move(arichDigs), fInstanceLabelARICH);
     evt.put(std::move(ssdDigs), fInstanceLabelSSD);    

--- a/Digitization/RelabelRawDigitModules_module.cc
+++ b/Digitization/RelabelRawDigitModules_module.cc
@@ -54,8 +54,7 @@ namespace emph {
     std::unique_ptr< std::vector<rawdata::SSDRawDigit> >   ssdDigs (new std::vector<rawdata::SSDRawDigit>);
 
     art::Handle< std::vector<rawdata::TRB3RawDigit> > arichHandle;
-    if (arichHandle.isValid()) {
-      evt.getByLabel(fRawDigitLabelARICH, arichHandle);
+    if (evt.getByLabel(fRawDigitLabelARICH, arichHandle)) {      
       for (unsigned int i = 0; i<arichHandle->size() ; ++i) {
 	rawdata::TRB3RawDigit digit ( (*arichHandle)[i]);
 	arichDigs->push_back(digit);
@@ -63,9 +62,7 @@ namespace emph {
     } // valid arich handle
 
     art::Handle< std::vector<rawdata::SSDRawDigit> > ssdHandle;
-    if (ssdHandle.isValid()) {
-      evt.getByLabel(fRawDigitLabelSSD, ssdHandle);
-
+    if (evt.getByLabel(fRawDigitLabelSSD, ssdHandle)) {
       for (unsigned int i = 0; i<ssdHandle->size(); ++i) {
 	rawdata::SSDRawDigit digit ( (*ssdHandle)[i]);
 	ssdDigs->push_back(digit);

--- a/Digitization/RelabelRawDigitModules_module.cc
+++ b/Digitization/RelabelRawDigitModules_module.cc
@@ -6,14 +6,11 @@
 // \author  lackey32@fnal.gov
 ///////////////////////////////////////////////////////////////////////////
 
+#include "art/Framework/Core/EDProducer.h"
 #include "art/Framework/Principal/Event.h"
 #include "art/Framework/Principal/Handle.h"
-#include "art/Framework/Services/Registry/ServiceHandle.h"
 #include "fhiclcpp/ParameterSet.h"
 #include "messagefacility/MessageLogger/MessageLogger.h"
-#include "art/Framework/Core/EDProducer.h"
-#include "art/Framework/Core/ModuleMacros.h"
-#include "canvas/Utilities/InputTag.h"
 
 #include "RawData/SSDRawDigit.h"
 #include "RawData/TRB3RawDigit.h"

--- a/Digitization/RelabelRawDigitModules_module.cc
+++ b/Digitization/RelabelRawDigitModules_module.cc
@@ -1,0 +1,88 @@
+///////////////////////////////////////////////////////////////////////////
+// \file    RelabelRawDigitModules_module.cc
+// \brief   Changes the module label for simulated digits.
+// Grabs SSD and ARICH simulated {SSD,TRB3}RawDigits from digitization output to
+// change their module label to the same as is used for data. 
+// \author  lackey32@fnal.gov
+///////////////////////////////////////////////////////////////////////////
+
+#include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/Handle.h"
+#include "art/Framework/Services/Registry/ServiceHandle.h"
+#include "fhiclcpp/ParameterSet.h"
+#include "messagefacility/MessageLogger/MessageLogger.h"
+#include "art/Framework/Core/EDProducer.h"
+#include "art/Framework/Core/ModuleMacros.h"
+#include "canvas/Utilities/InputTag.h"
+
+#include "RawData/SSDRawDigit.h"
+#include "RawData/TRB3RawDigit.h"
+
+using namespace emph;
+
+namespace emph {
+  class RelabelRawDigitModules : public art::EDProducer {
+  public:
+    explicit RelabelRawDigitModules(fhicl::ParameterSet const &pset);
+    virtual ~RelabelRawDigitModules();
+
+    void produce(art::Event& evt);
+
+  protected:
+    std::string fRawDigitLabelARICH;
+    std::string fRawDigitLabelSSD;
+    std::string fInstanceLabelARICH;
+    std::string fInstanceLabelSSD;
+  };
+
+  //--------------------------------------------------
+  RelabelRawDigitModules::RelabelRawDigitModules(fhicl::ParameterSet const &pset) :
+    EDProducer(pset),
+    fRawDigitLabelARICH   (pset.get< std::string >("RawDigitLabelARICH")),
+    fRawDigitLabelSSD     (pset.get< std::string >("RawDigitLabelSSD")),
+    fInstanceLabelARICH   (pset.get< std::string >("InstanceLabelARICH")),
+    fInstanceLabelSSD     (pset.get< std::string >("InstanceLabelSSD"))
+  {
+    produces<std::vector<rawdata::TRB3RawDigit> >(fInstanceLabelARICH);
+    produces<std::vector<rawdata::SSDRawDigit>  >(fInstanceLabelSSD);
+  }
+
+  RelabelRawDigitModules::~RelabelRawDigitModules()
+  {
+  }
+
+  void RelabelRawDigitModules::produce(art::Event& evt)
+  {
+    std::unique_ptr< std::vector<rawdata::TRB3RawDigit> > arichDigs (new std::vector<rawdata::TRB3RawDigit>);
+    std::unique_ptr< std::vector<rawdata::SSDRawDigit> >   ssdDigs (new std::vector<rawdata::SSDRawDigit>);
+
+    art::Handle< std::vector<rawdata::TRB3RawDigit> > arichHandle;
+    evt.getByLabel(fRawDigitLabelARICH, arichHandle);
+    art::Handle< std::vector<rawdata::SSDRawDigit> > ssdHandle;
+    evt.getByLabel(fRawDigitLabelSSD, ssdHandle);
+
+    // auto ssdHandle = evt.getHandle<std::vector<emph::rawdata::SSDRawDigit> >(fRawDigitLabelSSD);
+    for (unsigned int i = 0; i<ssdHandle->size(); ++i) {
+      rawdata::SSDRawDigit digit ( (*ssdHandle)[i]);
+      ssdDigs->push_back(digit);
+    }
+    //if (!ssdHandle.failedToGet()) ssdDigs = *ssdHandle;
+
+    for (unsigned int i = 0; i<arichHandle->size() ; ++i) {
+      rawdata::TRB3RawDigit digit ( (*arichHandle)[i]);
+      arichDigs->push_back(digit);
+    }
+
+    // for (size_t i = 0; i< ssdHandle->size(); ++i) {
+    //   art::Ptr<emph::rawdata::SSDRawDigit> digit(ssdHandle,i);
+    //   ssdDigs->push_back(digit);
+    // }
+
+    evt.put(std::move(arichDigs), fInstanceLabelARICH);
+    evt.put(std::move(ssdDigs), fInstanceLabelSSD);    
+
+  } // produce
+
+} // emph namespace
+
+DEFINE_ART_MODULE(RelabelRawDigitModules)

--- a/Digitization/RelabelRawDigitModules_module.cc
+++ b/Digitization/RelabelRawDigitModules_module.cc
@@ -54,19 +54,23 @@ namespace emph {
     std::unique_ptr< std::vector<rawdata::SSDRawDigit> >   ssdDigs (new std::vector<rawdata::SSDRawDigit>);
 
     art::Handle< std::vector<rawdata::TRB3RawDigit> > arichHandle;
-    evt.getByLabel(fRawDigitLabelARICH, arichHandle);
+    if (arichHandle.isValid()) {
+      evt.getByLabel(fRawDigitLabelARICH, arichHandle);
+      for (unsigned int i = 0; i<arichHandle->size() ; ++i) {
+	rawdata::TRB3RawDigit digit ( (*arichHandle)[i]);
+	arichDigs->push_back(digit);
+      }
+    } // valid arich handle
+
     art::Handle< std::vector<rawdata::SSDRawDigit> > ssdHandle;
-    evt.getByLabel(fRawDigitLabelSSD, ssdHandle);
+    if (ssdHandle.isValid()) {
+      evt.getByLabel(fRawDigitLabelSSD, ssdHandle);
 
-    for (unsigned int i = 0; i<ssdHandle->size(); ++i) {
-      rawdata::SSDRawDigit digit ( (*ssdHandle)[i]);
-      ssdDigs->push_back(digit);
-    }
-
-    for (unsigned int i = 0; i<arichHandle->size() ; ++i) {
-      rawdata::TRB3RawDigit digit ( (*arichHandle)[i]);
-      arichDigs->push_back(digit);
-    }
+      for (unsigned int i = 0; i<ssdHandle->size(); ++i) {
+	rawdata::SSDRawDigit digit ( (*ssdHandle)[i]);
+	ssdDigs->push_back(digit);
+      }
+    } // valid ssd handle
 
     evt.put(std::move(arichDigs), fInstanceLabelARICH);
     evt.put(std::move(ssdDigs), fInstanceLabelSSD);    

--- a/Digitization/digitization_job.fcl
+++ b/Digitization/digitization_job.fcl
@@ -35,13 +35,11 @@ physics:
 {
   producers:
   {
-#    raw:        @local::standard_ssddigitizer
     rawSSD:        @local::standard_ssddigitizer
     rawARICH:      @local::standard_arichdigitizer
     raw:           @local::standard_digitrelabel
   }
 
-#  digitizer: [ raw ]
   digitizer: [ rawSSD, rawARICH, raw ]
 
   trigger_paths: [ digitizer ]

--- a/Digitization/digitization_job.fcl
+++ b/Digitization/digitization_job.fcl
@@ -1,6 +1,7 @@
 #include "Services.fcl"
 #include "SSDDigitizer.fcl"
 #include "ARICHDigitizer.fcl"
+#include "RelabelRawDigitModules.fcl"
 
 process_name: Digitizer
 
@@ -23,6 +24,9 @@ outputs:
    module_type: RootOutput
    fileName:    "%ifb.dig.root"
    fastCloning: false
+   outputCommands: [ "keep *",
+                     "drop *_rawARICH_*_*",
+                     "drop *_rawSSD_*_*" ]
    
   }
 }
@@ -33,11 +37,12 @@ physics:
   {
 #    raw:        @local::standard_ssddigitizer
     rawSSD:        @local::standard_ssddigitizer
-    rawARICH:        @local::standard_arichdigitizer
+    rawARICH:      @local::standard_arichdigitizer
+    raw:           @local::standard_digitrelabel
   }
 
 #  digitizer: [ raw ]
-  digitizer: [ rawSSD, rawARICH ]
+  digitizer: [ rawSSD, rawARICH, raw ]
 
   trigger_paths: [ digitizer ]
   stream1: [ out1 ]

--- a/EventDisplay/EventDisplay3D_module.cc
+++ b/EventDisplay/EventDisplay3D_module.cc
@@ -167,7 +167,7 @@ emph::EventDisplay3D::EventDisplay3D(fhicl::ParameterSet const& pset):
   fDrawTrueSSDHits  ( pset.get<bool>       ("DrawTrueSSDHits",true) ),
   fMCTruthLabel     ( pset.get<std::string>("MCTruthLabel","geantgen") ),
   fDrawSSDDigits    ( pset.get<bool>       ("DrawSSDDigits",true) ),
-  fSSDDigitLabel    ( pset.get<std::string>("SSDDigitLabel","rawSSD:SSD") ),
+  fSSDDigitLabel    ( pset.get<std::string>("SSDDigitLabel","raw:SSD") ),
   fDrawSSDClusters  ( pset.get<bool>       ("DrawSSDClusters",true) ),
   fSSDClustLabel    ( pset.get<std::string>("SSDClustLabel","clust") ),
   fDrawTracks       ( pset.get<bool>       ("DrawTracks",true) ),

--- a/SSDReco/MakeSSDClusters.fcl
+++ b/SSDReco/MakeSSDClusters.fcl
@@ -3,7 +3,7 @@ BEGIN_PROLOG
 standard_ssdclust:
 {
   module_type: MakeSSDClusters
-  SSDRawLabel: "rawSSD:SSD"
+  SSDRawLabel: "raw:SSD"
   FillTTree:   false           # Make TTree for development/debugging?
   RowGap:      1              # If gap between RawDigits is larger than this, form a new cluster
   CheckDQ:     true           # Check data quality for event (requires running FillDataQual first)


### PR DESCRIPTION
Merge module that takes in the `rawSSD:SSD` and `rawARICH:ARICH` RawDigits  and creates `raw:SSD` and `raw:ARICH` RawDigits. Job fcl drops the original RawDigits from the file (they will still be visible in the file with `?` size.

In testing, I enabled arich clusters. Either that or ARICH reco has a memory leak (making it impossible to run over MC files with a reasonable number of events). I'm leaving it enabled with the hopes it will speed up fixing the problem. For people who want to run without those, you can remove arichcluster and arichreco from the `makecaf` part of [CAFMaker/prod_reco_caf_job.fcl](https://github.com/EMPHATICSoft/emphaticsoft/blob/main/CAFMaker/prod_reco_caf_job.fcl)

Any local instances of `rawSSD:SSD` and `rawARICH:ARICH` outside of the `Digitization` package should be changed back to `raw:SSD` and `raw:ARICH`.