### PR TITLE
Fixing TrackFiller for SSD-only sim

### DIFF
--- a/CAFMaker/TrackFiller.cxx
+++ b/CAFMaker/TrackFiller.cxx
@@ -30,10 +30,6 @@ namespace caf
       for (int i=0; i<3; ++i) 
 	sp.vtx[i] = p.Vtx()[i];
       sp.mom.SetXYZ(p.P()[0],p.P()[1],p.P()[2]);
-	if(arichIDs.size() == 0)continue;
-	sp.arich.trackID = arichIDs[c].trackID; 
-	sp.arich.scores = arichIDs[c].scores;
-	sp.arich.nhit =  arichIDs[c].nhit;
 	for (size_t i=0; i<p.NTrackSegments(); i++){     
         auto pts = p.GetTrackSegment(i);
 	caf::SRTrackSegment srts;
@@ -46,6 +42,11 @@ namespace caf
 	sp.Add(srts);
 	
       }
+	if(arichIDs.size() != 0){
+        sp.arich.trackID = arichIDs[c].trackID;
+        sp.arich.scores = arichIDs[c].scores;
+        sp.arich.nhit =  arichIDs[c].nhit;
+	}
       stdrec.trks.trk.push_back(sp);
    } // end of loop over tracks
   }  


### PR DESCRIPTION
I made a mistake and if there was no arich information, the track object wasn't saved, this fixes it