### PR TITLE
Fixed message facility printouts in G4Base and G4EMPH.

### DIFF
--- a/G4Base/ConvertMCTruthToG4.cxx
+++ b/G4Base/ConvertMCTruthToG4.cxx
@@ -178,7 +178,7 @@ namespace g4b{
 	  particleDefinition = fParticleTable->FindParticle(pdgCode);
 
 	if ( pdgCode > 1000000000) { // If the particle is a nucleus
-	  MF_LOG_DEBUG("ConvertPrimaryToGeant4") << ": %%% Nuclear PDG code = " << pdgCode
+	  mf::LogDebug("ConvertPrimaryToGeant4") << ": %%% Nuclear PDG code = " << pdgCode
 					      << " (x,y,z,t)=(" << x
 					      << "," << y
 					      << "," << z
@@ -197,7 +197,7 @@ namespace g4b{
 	// What if the PDG code is unknown?  This has been a known
 	// issue with GENIE.
 	if ( particleDefinition == 0 ){
-	  MF_LOG_DEBUG("ConvertPrimaryToGeant4") << ": %%% Code not found = " << pdgCode;
+	  mf::LogDebug("ConvertPrimaryToGeant4") << ": %%% Code not found = " << pdgCode;
 	  fUnknownPDG[ pdgCode ] += 1;
 	  continue;
 	}
@@ -229,7 +229,7 @@ namespace g4b{
 	// G4PrimaryParticle for access during tracking.
 	g4particle->SetUserInformation( primaryParticleInfo );
 
-	MF_LOG_DEBUG("ConvertPrimaryToGeant4") << ": %%% primary PDG=" << pdgCode
+	mf::LogDebug("ConvertPrimaryToGeant4") << ": %%% primary PDG=" << pdgCode
 					    << ", (x,y,z,t)=(" << x
 					    << "," << y
 					    << "," << z

--- a/G4Base/G4Helper.cxx
+++ b/G4Base/G4Helper.cxx
@@ -120,7 +120,7 @@ namespace g4b{
       delete fRunManager;
     }
     else{
-      MF_LOG_ERROR("G4Helper")
+      mf::LogError("G4Helper")
       << "G4Helper never initialized; probably because there were no input primary events";
     }
 
@@ -193,10 +193,10 @@ namespace g4b{
         factory.PrintAvailablePhysLists();
 /* #else
             std::vector<G4String> list = factory.AvailablePhysLists();
-            MF_LOG_VERBATIM("G4Helper")
+            mf::LogVerbatim("G4Helper")
             << "For reference: PhysicsLists in G4PhysListFactory are: ";
             for (size_t indx=0; indx < list.size(); ++indx ) {
-              MF_LOG_VERBATIM("G4Helper")
+              mf::LogVerbatim("G4Helper")
               << " [" << std::setw(2) << indx << "] "
               << "\"" << list[indx] << "\"";
             }
@@ -204,7 +204,7 @@ namespace g4b{
       }
 
       if ( ! physics ) {
-        MF_LOG_ERROR("G4Helper")
+        mf::LogError("G4Helper")
           << bywhom << "  could not construct \""
           << phListName
           << "\","
@@ -215,7 +215,7 @@ namespace g4b{
         phListName = "<none>"; // "QGSP_BERT";
 
       } else {
-        MF_LOG_VERBATIM("G4Helper")
+        mf::LogDebug("G4Helper")
         << bywhom
         << " constructed G4VUserPhysicsList \""
         << phListName
@@ -249,7 +249,7 @@ namespace g4b{
 
       if ( ! pcRegistry->IsKnownPhysicsConstructor(physProcName) ) {
 
-        MF_LOG_VERBATIM("G4Helper")
+        mf::LogVerbatim("G4Helper")
         << "G4PhysicsProcessFactorySingleton could not "
         << "construct a \""
         << physProcName
@@ -259,16 +259,16 @@ namespace g4b{
         // make sure we only do this once
         list_known_ctors = false;
         std::vector<G4String> list = pcRegistry->AvailablePhysicsConstructors();
-        MF_LOG_VERBATIM("G4Helper")
+        mf::LogVerbatim("G4Helper")
         << "For reference: PhysicsProcesses in "
         << "G4PhysicsProcessFactorySingleton are: ";
 
         if ( list.empty() )
-          MF_LOG_VERBATIM("G4Helper")
+          mf::LogVerbatim("G4Helper")
           << " ... no registered processes";
         else {
           for (size_t indx=0; indx < list.size(); ++indx ) {
-            MF_LOG_VERBATIM("G4Helper")
+            mf::LogVerbatim("G4Helper")
             << " [" << std::setw(2) << indx << "] "
             << "\"" << list[indx] << "\"";
           }
@@ -276,7 +276,7 @@ namespace g4b{
         continue;
       }
 
-      MF_LOG_VERBATIM("G4Helper")
+      mf::LogVerbatim("G4Helper")
       << "Adding \""
       << physProcName
       << "\" physics process to \""
@@ -289,8 +289,8 @@ namespace g4b{
 
 
       G4VModularPhysicsList* mpl = dynamic_cast<G4VModularPhysicsList*>(physics);
-      if      ( ! pctor ) MF_LOG_VERBATIM("G4Helper") << " ... failed with null pointer";
-      else if ( ! mpl )   MF_LOG_VERBATIM("G4Helper") << " ... failed, physics list wasn't a G4VModularPhysicsList";
+      if      ( ! pctor ) mf::LogVerbatim("G4Helper") << " ... failed with null pointer";
+      else if ( ! mpl )   mf::LogVerbatim("G4Helper") << " ... failed, physics list wasn't a G4VModularPhysicsList";
       else                mpl->RegisterPhysics(pctor);
 
       // Handle associated UI commands
@@ -299,7 +299,7 @@ namespace g4b{
 
       for ( unsigned int i=1; i < physProcParts.size(); ++i ) {
         if ( physProcParts[i] == "" ) continue;
-        MF_LOG_VERBATIM("G4Helper")
+        mf::LogVerbatim("G4Helper")
         << physProcParts[i];
 
         fUIManager->ApplyCommand(physProcParts[i]);
@@ -313,7 +313,7 @@ namespace g4b{
       auto mpl = dynamic_cast<G4VModularPhysicsList*>(physics);
       if(mpl) mpl->RegisterPhysics(new G4StepLimiterPhysics());
       else
-        MF_LOG_WARNING("G4Helper")
+        mf::LogWarning("G4Helper")
         << "Step limits requested, but unable to register G4StepLimiterPhysics"
         << "\n NO STEP LIMITS WILL BE APPLIED";
     }
@@ -328,7 +328,7 @@ namespace g4b{
   void G4Helper::SetParallelWorlds(std::vector<G4VUserParallelWorld*> pworlds)
   {
     for(auto const& pw : pworlds){
-      MF_LOG_DEBUG("G4Helper") << pw->GetName();
+      mf::LogDebug("G4Helper") << pw->GetName();
       fParallelWorlds.push_back(pw);
     }
 
@@ -363,7 +363,7 @@ namespace g4b{
       fUseStepLimits = true;
     }
     else{
-      MF_LOG_WARNING("G4Helper")
+      mf::LogWarning("G4Helper")
       << "Unable to find volume "
       << volumeName
       << " and set step size limit";

--- a/G4EMPH/FastStopAction.cxx
+++ b/G4EMPH/FastStopAction.cxx
@@ -86,7 +86,7 @@ namespace emph
   // Create our initial sim::SSDHit vector and add it to the vector of vectors
   void FastStopAction::PreTrackingAction(const G4Track* ) //track)
   {
-    //    MF_LOG_DEBUG("FastStopAction") << "pretracking step with track id: "
+    //    mf::LogDebug("FastStopAction") << "pretracking step with track id: "
     //				 << ParticleListAction::GetCurrentTrackID();
   }
 

--- a/G4EMPH/G4Alg.cxx
+++ b/G4EMPH/G4Alg.cxx
@@ -265,12 +265,12 @@ namespace emph {
         // ooops, factory failed ... let someone know
         
         const std::vector<std::string>& availActions = uafactory.AvailableUserActions();
-        MF_LOG_VERBATIM("G4Alg") << "emph::G4Alg requested UserAction \"" << uaname << "\" from "
+        mf::LogVerbatim("G4Alg") << "emph::G4Alg requested UserAction \"" << uaname << "\" from "
                               << "g4b::UserActionFactory" << std::endl
                               << "but it only knows about: ";
         for(size_t k=0; k<availActions.size(); ++k)
-          MF_LOG_VERBATIM("G4Alg") << "   " << availActions[k];
-        MF_LOG_VERBATIM("G4Alg") << "proceeding without this action";
+          mf::LogVerbatim("G4Alg") << "   " << availActions[k];
+        mf::LogVerbatim("G4Alg") << "proceeding without this action";
       }
     }
   }
@@ -391,7 +391,7 @@ namespace emph {
     g4b::UserActionManager*  uam = g4b::UserActionManager::Instance();
     dynamic_cast<emph::ParticleListAction*>(uam->GetAction(fPlaIndex))->ResetAbortFlag();
 
-    MF_LOG_DEBUG("G4Alg") << *mctruth;
+    mf::LogDebug("G4Alg") << *mctruth;
 
     if(trackIDOffset > 0){
       dynamic_cast<ParticleListAction *>(uam->GetAction(fPlaIndex))->ResetTrackIDOffset(trackIDOffset);

--- a/G4EMPH/ParticleListAction.cxx
+++ b/G4EMPH/ParticleListAction.cxx
@@ -114,7 +114,7 @@ namespace emph {
 	int nIterations = 0;
 	 while( itr != fParentIDMap.end() ){
 		 //std::cerr << "Iterating" << " Track ID: " << trackid << "itr: " << (*itr).second << std::endl;
-     		 MF_LOG_DEBUG("ParticleListAction") << "parentage for " << trackid
+     		 mf::LogDebug("ParticleListAction") << "parentage for " << trackid
 					 << " " << (*itr).second;
       		 // set the parentid to the current parent ID, when the loop ends
       		 // this id will be the first EM particle
@@ -130,7 +130,7 @@ namespace emph {
 
 
 
-	 MF_LOG_DEBUG("ParticleListAction") << "final parent ID " << parentid;
+	 mf::LogDebug("ParticleListAction") << "final parent ID " << parentid;
 
 	 return parentid;
  }
@@ -263,13 +263,13 @@ namespace emph {
 
     std::cerr << "Getting Stuff" << std::endl;
 
-    // was MF_LOG_DEBUG
-    MF_LOG_INFO("ParticleListAction") << "preparing to track " << fCurrentTrackID
+    // was mf::LogDebug
+    mf::LogInfo("ParticleListAction") << "preparing to track " << fCurrentTrackID
 				       << " pdg " << pdg
 				       << " with parent " << parentID;
 
     auto trackPos = track->GetPosition();
-    MF_LOG_INFO("ParticleListAction") << "Track has start position = (" <<
+    mf::LogInfo("ParticleListAction") << "Track has start position = (" <<
       trackPos[0] << "," << trackPos[1] << "," << trackPos[2] << ")" << 
       std::endl;
     
@@ -333,7 +333,7 @@ namespace emph {
 	
         std::cerr << "Got Parent" << fCurrentTrackID << std::endl;
 
-	MF_LOG_DEBUG("ParticleListAction") << "current track ID " << fCurrentTrackID;
+	mf::LogDebug("ParticleListAction") << "current track ID " << fCurrentTrackID;
 	
 	// check that fCurrentTrackID is in the particle list - it is possible
 	// that this particle's parent is a particle that did not get tracked.
@@ -350,7 +350,7 @@ namespace emph {
 	  // and adding trajectory points to it
 	  fParticle = 0;
 	  
-	  MF_LOG_DEBUG("ParticleListAction") << "killing TrackID: " << trackID << " bc EM daughter, "
+	  mf::LogDebug("ParticleListAction") << "killing TrackID: " << trackID << " bc EM daughter, "
 	 				     << process_name << " " << pdg
 	 				     << ", use track id " << fCurrentTrackID;
 	  
@@ -366,7 +366,7 @@ namespace emph {
 	if ( energy < fEnergyCut ){
           std::cerr << "Particle is lower than the threshold..." << std::endl;
 	  fParticle = 0;
-	  MF_LOG_DEBUG("ParticleListAction") << "killing TrackID: " << fCurrentTrackID << " energy/fEnergyCut";
+	  mf::LogDebug("ParticleListAction") << "killing TrackID: " << fCurrentTrackID << " energy/fEnergyCut";
 	  
 	  // do add the particle to the parent id map though
 	  // and set the current track id to be it's ultimate parent
@@ -442,7 +442,7 @@ namespace emph {
       fParticleNav->Add(fParticle);
       
       if(fTrackIDToMCTruthIndex.count(fCurrentTrackID) > 0)
-	MF_LOG_WARNING("ParticleListAction") << "attempting to put " << fCurrentTrackID
+	mf::LogWarning("ParticleListAction") << "attempting to put " << fCurrentTrackID
 					     << " into fTrackIDToMCTruthIndex map "
 					     << " particle is\n" << *fParticle;
       
@@ -546,7 +546,7 @@ namespace emph {
 
     //    fTrackIDOffset = highestID + 100;
 
-    MF_LOG_DEBUG("ParticleListAction") << *fParticleNav << "\ntrack id offset is now " << fTrackIDOffset;
+    mf::LogDebug("ParticleListAction") << "track id offset is now " << fTrackIDOffset;
 
     return plist;
   }
@@ -625,7 +625,7 @@ namespace emph {
 		  fParticleNav->end(), 
 		  updateDaughterInformation);
     
-    MF_LOG_DEBUG("ParticleListAction") << *fParticleNav;
+    mf::LogDebug("ParticleListAction") << *fParticleNav;
   }
 
 } // end namespace

--- a/G4EMPH/SSDHitAction.cxx
+++ b/G4EMPH/SSDHitAction.cxx
@@ -81,14 +81,14 @@ namespace emph
     //    std::vector<sim::SSDHit> ssdVec;
     //    fSSDHits.push_back(ssdVec);
 
-    //    MF_LOG_DEBUG("SSDHitAction") << "pretracking step with track id: "
+    //    mf::LogDebug("SSDHitAction") << "pretracking step with track id: "
     //				 << ParticleListAction::GetCurrentTrackID();
   }
 
   //-------------------------------------------------------------
   void SSDHitAction::PostTrackingAction( const G4Track* /*track*/) 
   {
-    //    MF_LOG_DEBUG("SSDHitAction") 
+    //    mf::LogDebug("SSDHitAction") 
     //      << "done tracking for this g4 track, recorded "
     //      << fSSDHits[fSSDHits.size()-1].size() << " SSD hits";
   }
@@ -118,7 +118,7 @@ namespace emph
     const CLHEP::Hep3Vector &pos  = track->GetPosition();                   // End of the step
     const CLHEP::Hep3Vector &mom  = track->GetMomentum();
 
-    MF_LOG_DEBUG("SSDHitAction") 
+    mf::LogDebug("SSDHitAction") 
       << " momentum = "
       << mom.x() << " " << mom.y() << " " 
       << mom.z() << " " << mom.mag() 

--- a/G4EMPH/g4gen_job.fcl
+++ b/G4EMPH/g4gen_job.fcl
@@ -11,7 +11,9 @@ services:
   MagneticField: @local::standard_magfield
   RunHistoryService: @local::standard_runhistory
   Geometry: @local::standard_geometry
-  
+
+  # uncomment for debug messages
+#  message: { debugModules: ["*"] destinations: { debugmsg:{type: "cout" threshold: "DEBUG"} } }  
   # Load the service that manages root files for histograms.
 #  TFileService: { fileName: "daq2root_%r_%s.root" closeFileFast: false }
   


### PR DESCRIPTION
Changed all `MF_LOG_STUFF` to `mf::LogStuff`. You can now see printouts from the `ParticleListAction` and `SSDHitAction` code (if enabled in the fcl).