### PR TITLE
Fix case typo: use PSigma instead of Psigma in BeamGen.fcl

### DIFF
--- a/G4EMPH/BeamGen.fcl
+++ b/G4EMPH/BeamGen.fcl
@@ -29,7 +29,7 @@ standard_beamgen:
 
 # parameters for Gaussian total momentum distribution (the only option for now)
   PMean:		     120.
-  Psigma:		     1.e-3
+  PSigma:		     1.e-3
 
 # parameters for flat distributions of beam slopes
   PXmax:		     0.1
@@ -60,7 +60,7 @@ proton120.PYmin: -1.e-5
 proton4: @local::standard_beamgen
 proton4.particleType: "proton"
 proton4.PMean: 4
-proton4.Psigma: 0.2
+proton4.PSigma: 0.2
 proton4.xyDistSource: "flatxy"
 proton4.pxyDistSource: "flatpxy"
 proton4.Xmax: 2.


### PR DESCRIPTION
This PR fixes a typo in BeamGen.fcl where the momentum spread parameter was mistakenly written as Psigma instead of the correct PSigma.
Due to this, the beam generator was ignoring the value and defaulting to a fixed spread.
After setting UseRunHistory: false and correcting the key to PSigma, the beam momentum spread now behaves as expected.