### PR TITLE
Fixed missing positions in the no-magnet gdmls

### DIFF
--- a/ConstBase/Geometry/phase1c_Air.gdml
+++ b/ConstBase/Geometry/phase1c_Air.gdml
@@ -56,6 +56,7 @@
 	    
 	    <quantity name="target_width" value="100.0" unit="mm"/>
 	    <quantity name="target_height" value="50.0" unit="mm"/>
+	    <quantity name="target_depth" value="100" unit="mm"/>
 	    
 	    <position name="target_pos" x="0" y="0" z="380.5"/>
 
@@ -115,102 +116,102 @@
 
 	<position name="ssdsensor_0_0_0_pos" x="0" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick+0"/>
 	<position name="ssd_bkpln_0_0_0_pos" x="0" y="0" z="0*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick+0"/>
-	<rotation name="ssdsensor_0_0_0_rot" x="180.0*0" y="0" z="1" unit="deg"/>
+	<rotation name="ssdsensor_0_0_0_rot" x="180.0*0" y="0" z="0" unit="deg"/>
 	<position name="ssdsensor_0_1_0_pos" x="0" y="0" z="(1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1-1)*ssd_bkpln_thick+0"/>
 	<position name="ssd_bkpln_0_1_0_pos" x="0" y="0" z="1*ssdD0_thick+(1-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick+0"/>
-	<rotation name="ssdsensor_0_1_0_rot" x="180.0*1" y="0" z="1" unit="deg"/>
+	<rotation name="ssdsensor_0_1_0_rot" x="180.0*1" y="0" z="90" unit="deg"/>
 	<position name="ssdStation1_pos" x="0" y="0" z="ssdStation1_shift+ssdD0_thick-0.5*mount_thick"/>
 
 	<position name="ssdsensor_1_0_0_pos" x="0" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick+0"/>
 	<position name="ssd_bkpln_1_0_0_pos" x="0" y="0" z="0*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick+0"/>
-	<rotation name="ssdsensor_1_0_0_rot" x="180.0*0" y="0" z="1" unit="deg"/>
+	<rotation name="ssdsensor_1_0_0_rot" x="180.0*0" y="0" z="0" unit="deg"/>
 	<position name="ssdsensor_1_1_0_pos" x="0" y="0" z="(1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1-1)*ssd_bkpln_thick+0"/>
 	<position name="ssd_bkpln_1_1_0_pos" x="0" y="0" z="1*ssdD0_thick+(1-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick+0"/>
-	<rotation name="ssdsensor_1_1_0_rot" x="180.0*1" y="0" z="1" unit="deg"/>
+	<rotation name="ssdsensor_1_1_0_rot" x="180.0*1" y="0" z="90" unit="deg"/>
 	<position name="ssdStation2_pos" x="0" y="0" z="ssdStation2_shift+ssdD0_thick-0.5*mount_thick"/>
 
 	<position name="ssdsensor_2_0_0_pos" x="0" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick+0"/>
 	<position name="ssd_bkpln_2_0_0_pos" x="0" y="0" z="0*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick+0"/>
-	<rotation name="ssdsensor_2_0_0_rot" x="180.0*0" y="0" z="1" unit="deg"/>
+	<rotation name="ssdsensor_2_0_0_rot" x="180.0*0" y="0" z="315" unit="deg"/>
 	<position name="ssdsensor_2_1_0_pos" x="0" y="0" z="(1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1-1)*ssd_bkpln_thick+0"/>
 	<position name="ssd_bkpln_2_1_0_pos" x="0" y="0" z="1*ssdD0_thick+(1-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick+0"/>
-	<rotation name="ssdsensor_2_1_0_rot" x="180.0*0" y="0" z="1" unit="deg"/>
+	<rotation name="ssdsensor_2_1_0_rot" x="180.0*0" y="0" z="0" unit="deg"/>
 	<position name="ssdsensor_2_2_0_pos" x="0" y="0" z="0.5*ssdD0_thick+ssd_bkpln_thick+0.5*mount_thick+0"/>
 	<position name="ssd_bkpln_2_2_0_pos" x="0" y="0" z="0.5*ssd_bkpln_thick+0.5*mount_thick+0"/>
-	<rotation name="ssdsensor_2_2_0_rot" x="180.0*1" y="0" z="1" unit="deg"/>
+	<rotation name="ssdsensor_2_2_0_rot" x="180.0*1" y="0" z="90" unit="deg"/>
 	<position name="ssdStation3_pos" x="0" y="0" z="ssdStation3_shift+ssdD0_thick-0.5*mount_thick"/>
 
 	<position name="ssdsensor_3_0_0_pos" x="0" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick+0"/>
 	<position name="ssd_bkpln_3_0_0_pos" x="0" y="0" z="0*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick+0"/>
-	<rotation name="ssdsensor_3_0_0_rot" x="180.0*0" y="0" z="1" unit="deg"/>
+	<rotation name="ssdsensor_3_0_0_rot" x="180.0*0" y="0" z="315" unit="deg"/>
 	<position name="ssdsensor_3_1_0_pos" x="0" y="0" z="(1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1-1)*ssd_bkpln_thick+0"/>
 	<position name="ssd_bkpln_3_1_0_pos" x="0" y="0" z="1*ssdD0_thick+(1-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick+0"/>
-	<rotation name="ssdsensor_3_1_0_rot" x="180.0*0" y="0" z="1" unit="deg"/>
+	<rotation name="ssdsensor_3_1_0_rot" x="180.0*0" y="0" z="0" unit="deg"/>
 	<position name="ssdsensor_3_2_0_pos" x="0" y="0" z="0.5*ssdD0_thick+ssd_bkpln_thick+0.5*mount_thick+0"/>
 	<position name="ssd_bkpln_3_2_0_pos" x="0" y="0" z="0.5*ssd_bkpln_thick+0.5*mount_thick+0"/>
-	<rotation name="ssdsensor_3_2_0_rot" x="180.0*1" y="0" z="1" unit="deg"/>
+	<rotation name="ssdsensor_3_2_0_rot" x="180.0*1" y="0" z="90" unit="deg"/>
 	<position name="ssdStation4_pos" x="0" y="0" z="ssdStation4_shift+ssdD0_thick-0.5*mount_thick"/>
 
 	<position name="ssdsensor_4_0_0_pos" x="0" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick+0"/>
 	<position name="ssd_bkpln_4_0_0_pos" x="0" y="0" z="0*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick+0"/>
-	<rotation name="ssdsensor_4_0_0_rot" x="180.0*0" y="0" z="1" unit="deg"/>
+	<rotation name="ssdsensor_4_0_0_rot" x="180.0*0" y="0" z="0" unit="deg"/>
 	<position name="ssdsensor_4_1_0_pos" x="0" y="0" z="(1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1-1)*ssd_bkpln_thick+0"/>
 	<position name="ssd_bkpln_4_1_0_pos" x="0" y="0" z="1*ssdD0_thick+(1-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick+0"/>
-	<rotation name="ssdsensor_4_1_0_rot" x="180.0*1" y="0" z="1" unit="deg"/>
+	<rotation name="ssdsensor_4_1_0_rot" x="180.0*1" y="0" z="90" unit="deg"/>
 	<position name="ssdStation5_pos" x="0" y="0" z="ssdStation5_shift+ssdD0_thick-0.5*mount_thick"/>
 
 	<position name="ssdsensor_5_0_0_pos" x="-18.23" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick+0"/>
 	<position name="ssd_bkpln_5_0_0_pos" x="-18.23" y="0" z="0*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick+0"/>
-	<rotation name="ssdsensor_5_0_0_rot" x="180.0*0" y="0" z="1" unit="deg"/>
+	<rotation name="ssdsensor_5_0_0_rot" x="180.0*0" y="0" z="270" unit="deg"/>
 	<position name="ssdsensor_5_0_1_pos" x="18.23" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick+0"/>
 	<position name="ssd_bkpln_5_0_1_pos" x="18.23" y="0" z="0*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick+0"/>
-	<rotation name="ssdsensor_5_0_1_rot" x="180.0*0" y="0" z="1" unit="deg"/>
+	<rotation name="ssdsensor_5_0_1_rot" x="180.0*0" y="0" z="90" unit="deg"/>
 	<position name="ssdsensor_5_1_0_pos" x="0" y="-18.23" z="(1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1-1)*ssd_bkpln_thick+0"/>
 	<position name="ssd_bkpln_5_1_0_pos" x="0" y="-18.23" z="1*ssdD0_thick+(1-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick+0"/>
-	<rotation name="ssdsensor_5_1_0_rot" x="180.0*1" y="0" z="1" unit="deg"/>
+	<rotation name="ssdsensor_5_1_0_rot" x="180.0*1" y="0" z="0" unit="deg"/>
 	<position name="ssdsensor_5_1_1_pos" x="0" y="18.23" z="(1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1-1)*ssd_bkpln_thick+0"/>
 	<position name="ssd_bkpln_5_1_1_pos" x="0" y="18.23" z="1*ssdD0_thick+(1-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick+0"/>
-	<rotation name="ssdsensor_5_1_1_rot" x="180.0*1" y="0" z="1" unit="deg"/>
+	<rotation name="ssdsensor_5_1_1_rot" x="180.0*1" y="0" z="180" unit="deg"/>
 	<position name="ssdsensor_5_2_0_pos" x="12.92" y="-12.92" z="0.5*ssdD0_thick+ssd_bkpln_thick+0.5*mount_thick+0"/>
 	<position name="ssd_bkpln_5_2_0_pos" x="12.92" y="-12.92" z="0.5*ssd_bkpln_thick+0.5*mount_thick+0"/>
-	<rotation name="ssdsensor_5_2_0_rot" x="180.0*1" y="0" z="1" unit="deg"/>
+	<rotation name="ssdsensor_5_2_0_rot" x="180.0*1" y="0" z="45" unit="deg"/>
 	<position name="ssdsensor_5_2_1_pos" x="-12.92" y="12.92" z="0.5*ssdD0_thick+ssd_bkpln_thick+0.5*mount_thick+0"/>
 	<position name="ssd_bkpln_5_2_1_pos" x="-12.92" y="12.92" z="0.5*ssd_bkpln_thick+0.5*mount_thick+0"/>
-	<rotation name="ssdsensor_5_2_1_rot" x="180.0*1" y="0" z="1" unit="deg"/>
+	<rotation name="ssdsensor_5_2_1_rot" x="180.0*1" y="0" z="225" unit="deg"/>
 	<position name="ssdStation6_pos" x="0" y="0" z="ssdStation6_shift+ssdD0_thick-0.5*mount_thick"/>
 
 	<position name="ssdsensor_6_0_0_pos" x="-18.23" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick+0"/>
 	<position name="ssd_bkpln_6_0_0_pos" x="-18.23" y="0" z="0*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick+0"/>
-	<rotation name="ssdsensor_6_0_0_rot" x="180.0*0" y="0" z="1" unit="deg"/>
+	<rotation name="ssdsensor_6_0_0_rot" x="180.0*0" y="0" z="270" unit="deg"/>
 	<position name="ssdsensor_6_0_1_pos" x="18.23" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick+0"/>
 	<position name="ssd_bkpln_6_0_1_pos" x="18.23" y="0" z="0*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick+0"/>
-	<rotation name="ssdsensor_6_0_1_rot" x="180.0*0" y="0" z="1" unit="deg"/>
+	<rotation name="ssdsensor_6_0_1_rot" x="180.0*0" y="0" z="90" unit="deg"/>
 	<position name="ssdsensor_6_1_0_pos" x="0" y="-18.23" z="(1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1-1)*ssd_bkpln_thick+0"/>
 	<position name="ssd_bkpln_6_1_0_pos" x="0" y="-18.23" z="1*ssdD0_thick+(1-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick+0"/>
-	<rotation name="ssdsensor_6_1_0_rot" x="180.0*1" y="0" z="1" unit="deg"/>
+	<rotation name="ssdsensor_6_1_0_rot" x="180.0*1" y="0" z="0" unit="deg"/>
 	<position name="ssdsensor_6_1_1_pos" x="0" y="18.23" z="(1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1-1)*ssd_bkpln_thick+0"/>
 	<position name="ssd_bkpln_6_1_1_pos" x="0" y="18.23" z="1*ssdD0_thick+(1-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick+0"/>
-	<rotation name="ssdsensor_6_1_1_rot" x="180.0*1" y="0" z="1" unit="deg"/>
+	<rotation name="ssdsensor_6_1_1_rot" x="180.0*1" y="0" z="180" unit="deg"/>
 	<position name="ssdsensor_6_2_0_pos" x="12.92" y="-12.92" z="0.5*ssdD0_thick+ssd_bkpln_thick+0.5*mount_thick+0"/>
 	<position name="ssd_bkpln_6_2_0_pos" x="12.92" y="-12.92" z="0.5*ssd_bkpln_thick+0.5*mount_thick+0"/>
-	<rotation name="ssdsensor_6_2_0_rot" x="180.0*1" y="0" z="1" unit="deg"/>
+	<rotation name="ssdsensor_6_2_0_rot" x="180.0*1" y="0" z="45" unit="deg"/>
 	<position name="ssdsensor_6_2_1_pos" x="-12.92" y="12.92" z="0.5*ssdD0_thick+ssd_bkpln_thick+0.5*mount_thick+0"/>
 	<position name="ssd_bkpln_6_2_1_pos" x="-12.92" y="12.92" z="0.5*ssd_bkpln_thick+0.5*mount_thick+0"/>
-	<rotation name="ssdsensor_6_2_1_rot" x="180.0*1" y="0" z="1" unit="deg"/>
+	<rotation name="ssdsensor_6_2_1_rot" x="180.0*1" y="0" z="225" unit="deg"/>
 	<position name="ssdStation7_pos" x="0" y="0" z="ssdStation7_shift+ssdD0_thick-0.5*mount_thick"/>
 
 	<position name="ssdsensor_7_0_0_pos" x="-18.23" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick+0"/>
 	<position name="ssd_bkpln_7_0_0_pos" x="-18.23" y="0" z="0*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick+0"/>
-	<rotation name="ssdsensor_7_0_0_rot" x="180.0*0" y="0" z="1" unit="deg"/>
+	<rotation name="ssdsensor_7_0_0_rot" x="180.0*0" y="0" z="270" unit="deg"/>
 	<position name="ssdsensor_7_0_1_pos" x="18.23" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick+0"/>
 	<position name="ssd_bkpln_7_0_1_pos" x="18.23" y="0" z="0*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick+0"/>
-	<rotation name="ssdsensor_7_0_1_rot" x="180.0*0" y="0" z="1" unit="deg"/>
+	<rotation name="ssdsensor_7_0_1_rot" x="180.0*0" y="0" z="90" unit="deg"/>
 	<position name="ssdsensor_7_1_0_pos" x="0" y="-18.23" z="(1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1-1)*ssd_bkpln_thick+0"/>
 	<position name="ssd_bkpln_7_1_0_pos" x="0" y="-18.23" z="1*ssdD0_thick+(1-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick+0"/>
-	<rotation name="ssdsensor_7_1_0_rot" x="180.0*1" y="0" z="1" unit="deg"/>
+	<rotation name="ssdsensor_7_1_0_rot" x="180.0*1" y="0" z="0" unit="deg"/>
 	<position name="ssdsensor_7_1_1_pos" x="0" y="19.23" z="(1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1-1)*ssd_bkpln_thick+0"/>
 	<position name="ssd_bkpln_7_1_1_pos" x="0" y="19.23" z="1*ssdD0_thick+(1-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick+0"/>
-	<rotation name="ssdsensor_7_1_1_rot" x="180.0*1" y="0" z="1" unit="deg"/>
+	<rotation name="ssdsensor_7_1_1_rot" x="180.0*1" y="0" z="180" unit="deg"/>
 	<position name="ssdmount_local_0_0_pos" x="0" y="0" z="0"/>
 	<position name="ssdmount_0_0_pos" x="0" y="0" z="0+0.5*mount_thick"/>
 	<rotation name="ssdmount_0_0_rot" x="-0.44" y="-2.02" unit="deg"/>
@@ -2679,8 +2680,7 @@ values="202.14067278287462 12.054573032169143
 
 	 <!-- BELOW IS FOR TARGET -->
 
-	 <box name="target_box" x="target_width" y="target_height" z="" />
-
+	 <box name="target_box" x="target_width" y="target_height" z="target_depth" />
 
 	 <!-- ABOVE IS FOR TARGET -->
 

--- a/ConstBase/Geometry/phase1c_Empty_7S_nomag.gdml
+++ b/ConstBase/Geometry/phase1c_Empty_7S_nomag.gdml
@@ -8,6 +8,2127 @@
 --> 
 
 <define>
+	
+	<constant name="DEG2RAD" value="pi/180." />
+	<quantity name="world_size" value="10000." unit="mm"/>
+	<quantity name="Tolerance_space" value="1." unit="mm" />
+	<position name="center" x="0" y="0" z="0" unit="mm"/>
+	
+    <!-- BELOW IS FOR T0 -->
+		
+	<quantity name="T0_length" value="280.0" unit="mm"/>
+	<quantity name="T0_width" value="210.0" unit="mm"/>
+	<quantity name="T0_height" value="300.0" unit="mm"/>
+	<quantity name="T0_shift" value="-267.5" unit="mm"/>
+	<quantity name="T0_acrylic_shift" value="40.0" unit="mm"/>
+	<position name="T0_pos" z="T0_shift+T0_acrylic_shift"/>
+
+	<quantity name="T0_acrylic_length" value="150.0" unit="mm"/>
+	<quantity name="T0_acrylic_width" value="3.0" unit="mm"/>
+	<quantity name="T0_acrylic_height" value="3.0" unit="mm"/>
+		
+	<position name="T0_acrylic0_pos" x="T0_acrylic_width*(0-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*0"/>
+	<position name="T0_acrylic1_pos" x="T0_acrylic_width*(1-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*1"/>
+	<position name="T0_acrylic2_pos" x="T0_acrylic_width*(2-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*0"/>
+	<position name="T0_acrylic3_pos" x="T0_acrylic_width*(3-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*1"/>
+	<position name="T0_acrylic4_pos" x="T0_acrylic_width*(4-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*0"/>
+	<position name="T0_acrylic5_pos" x="T0_acrylic_width*(5-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*1"/>
+	<position name="T0_acrylic6_pos" x="T0_acrylic_width*(6-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*0"/>
+	<position name="T0_acrylic7_pos" x="T0_acrylic_width*(7-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*1"/>
+	<position name="T0_acrylic8_pos" x="T0_acrylic_width*(8-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*0"/>
+	<position name="T0_acrylic9_pos" x="T0_acrylic_width*(9-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*1"/>
+	<position name="T0_acrylic10_pos" x="T0_acrylic_width*(10-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*0"/>
+	<position name="T0_acrylic11_pos" x="T0_acrylic_width*(11-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*1"/>
+	<position name="T0_acrylic12_pos" x="T0_acrylic_width*(12-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*0"/>
+	<position name="T0_acrylic13_pos" x="T0_acrylic_width*(13-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*1"/>
+	<position name="T0_acrylic14_pos" x="T0_acrylic_width*(14-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*0"/>
+	<position name="T0_acrylic15_pos" x="T0_acrylic_width*(15-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*1"/>
+	<position name="T0_acrylic16_pos" x="T0_acrylic_width*(16-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*0"/>
+	<position name="T0_acrylic17_pos" x="T0_acrylic_width*(17-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*1"/>
+	<position name="T0_acrylic18_pos" x="T0_acrylic_width*(18-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*0"/>
+	<position name="T0_acrylic19_pos" x="T0_acrylic_width*(19-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*1"/>
+	    
+    <rotation name="T0_union1_rot" x="90" unit="deg"/>
+	<rotation name="T0_acrylic_rot" x="-45" unit="deg"/>
+
+	<!-- ABOVE IS FOR T0 -->
+	<!-- BELOW IS FOR TARGET -->
+	    
+	    <quantity name="target_width" value="100.0" unit="mm"/>
+	    <quantity name="target_height" value="50.0" unit="mm"/>
+	    <quantity name="target_depth" value="100" unit="mm"/>
+	    
+	    <position name="target_pos" x="0" y="0" z="380.5"/>
+
+	 <!-- ABOVE IS FOR TARGET -->
+
+  <!-- BELOW IS FOR SSD -->
+
+	<quantity name="ssdD0_thick" value=".300" unit="mm"/>
+	<quantity name="ssdD0_height" value="38.46" unit="mm"/>
+	<quantity name="ssdD0_width" value="98.33" unit="mm"/>
+	
+	<quantity name="ssdD0_chanwidth" value="0.059999" unit="mm"/>
+	<quantity name="ssdD0_changap" value="0.000001" unit="mm"/>
+	
+	<quantity name="ssdD0_overlap" value="2.0" unit="mm"/>
+	<quantity name="ssd_bkpln_thick" value=".300" unit="mm"/>
+	
+	<quantity name="ssdStation0_shift" value="0" unit="mm"/>
+	<quantity name="ssdStation1_shift" value="281" unit="mm"/>
+	<quantity name="ssdStation2_shift" value="501" unit="mm"/>
+	<quantity name="ssdStation3_shift" value="615" unit="mm"/>
+	<quantity name="ssdStation4_shift" value="846" unit="mm"/>
+	<quantity name="ssdStation5_shift" value="1146.38" unit="mm"/>
+	<quantity name="ssdStation6_shift" value="1471.82" unit="mm"/>
+	
+	<quantity name="mount_thick" value="6.35" unit="mm" />
+	<quantity name="mount_width" value="115.98" unit="mm" />
+	<quantity name="mount_hole" value="80.00" unit="mm" />
+	<quantity name="mount_enclosure_size" value="200" unit="mm" />
+
+	<quantity name="Mylar_Window_thick" value="0.500" unit="mm" />
+	<quantity name="Mylar_shift" value="20" unit="mm"/>
+	    
+	<quantity name="ssdStationsingleLength" value="50" unit="mm" />
+	<quantity name="ssdStationsingleWidth" value="300" unit="mm" />
+	<quantity name="ssdStationsingleHeight" value="300" unit="mm" />
+	<position name="ssdStation0_pos" x="0" y="0" z="ssdStation0_shift+ssdD0_thick-0.5*mount_thick"/>
+
+	<position name="ssdsensor_0_0_0_pos" x="0" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_0_0_0_pos" x="0" y="0" z="0*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_0_0_0_rot" x="180.0*0" y="0" z="0" unit="deg"/>
+	<position name="ssdsensor_0_1_0_pos" x="0" y="0" z="(1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_0_1_0_pos" x="0" y="0" z="1*ssdD0_thick+(1-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_0_1_0_rot" x="180.0*1" y="0" z="90" unit="deg"/>
+	<position name="ssdStation1_pos" x="0" y="0" z="ssdStation1_shift+ssdD0_thick-0.5*mount_thick"/>
+
+	<position name="ssdsensor_1_0_0_pos" x="0" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_1_0_0_pos" x="0" y="0" z="0*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_1_0_0_rot" x="180.0*0" y="0" z="0" unit="deg"/>
+	<position name="ssdsensor_1_1_0_pos" x="0" y="0" z="(1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_1_1_0_pos" x="0" y="0" z="1*ssdD0_thick+(1-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_1_1_0_rot" x="180.0*1" y="0" z="90" unit="deg"/>
+	<position name="ssdStation2_pos" x="0" y="0" z="ssdStation2_shift+ssdD0_thick-0.5*mount_thick"/>
+
+	<position name="ssdsensor_2_0_0_pos" x="0" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_2_0_0_pos" x="0" y="0" z="0*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_2_0_0_rot" x="180.0*0" y="0" z="315" unit="deg"/>
+	<position name="ssdsensor_2_1_0_pos" x="0" y="0" z="(1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_2_1_0_pos" x="0" y="0" z="1*ssdD0_thick+(1-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_2_1_0_rot" x="180.0*0" y="0" z="0" unit="deg"/>
+	<position name="ssdsensor_2_2_0_pos" x="0" y="0" z="0.5*ssdD0_thick+ssd_bkpln_thick+0.5*mount_thick+0"/>
+	<position name="ssd_bkpln_2_2_0_pos" x="0" y="0" z="0.5*ssd_bkpln_thick+0.5*mount_thick+0"/>
+	<rotation name="ssdsensor_2_2_0_rot" x="180.0*1" y="0" z="90" unit="deg"/>
+	<position name="ssdStation3_pos" x="0" y="0" z="ssdStation3_shift+ssdD0_thick-0.5*mount_thick"/>
+
+	<position name="ssdsensor_3_0_0_pos" x="0" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_3_0_0_pos" x="0" y="0" z="0*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_3_0_0_rot" x="180.0*0" y="0" z="315" unit="deg"/>
+	<position name="ssdsensor_3_1_0_pos" x="0" y="0" z="(1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_3_1_0_pos" x="0" y="0" z="1*ssdD0_thick+(1-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_3_1_0_rot" x="180.0*0" y="0" z="0" unit="deg"/>
+	<position name="ssdsensor_3_2_0_pos" x="0" y="0" z="0.5*ssdD0_thick+ssd_bkpln_thick+0.5*mount_thick+0"/>
+	<position name="ssd_bkpln_3_2_0_pos" x="0" y="0" z="0.5*ssd_bkpln_thick+0.5*mount_thick+0"/>
+	<rotation name="ssdsensor_3_2_0_rot" x="180.0*1" y="0" z="90" unit="deg"/>
+	<position name="ssdStation4_pos" x="0" y="0" z="ssdStation4_shift+ssdD0_thick-0.5*mount_thick"/>
+
+	<position name="ssdsensor_4_0_0_pos" x="0" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_4_0_0_pos" x="0" y="0" z="0*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_4_0_0_rot" x="180.0*0" y="0" z="0" unit="deg"/>
+	<position name="ssdsensor_4_1_0_pos" x="0" y="0" z="(1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_4_1_0_pos" x="0" y="0" z="1*ssdD0_thick+(1-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_4_1_0_rot" x="180.0*1" y="0" z="90" unit="deg"/>
+	<position name="ssdStation5_pos" x="0" y="0" z="ssdStation5_shift+ssdD0_thick-0.5*mount_thick"/>
+
+	<position name="ssdsensor_5_0_0_pos" x="-18.23" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_5_0_0_pos" x="-18.23" y="0" z="0*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_5_0_0_rot" x="180.0*0" y="0" z="270" unit="deg"/>
+	<position name="ssdsensor_5_0_1_pos" x="18.23" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_5_0_1_pos" x="18.23" y="0" z="0*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_5_0_1_rot" x="180.0*0" y="0" z="90" unit="deg"/>
+	<position name="ssdsensor_5_1_0_pos" x="0" y="-18.23" z="(1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_5_1_0_pos" x="0" y="-18.23" z="1*ssdD0_thick+(1-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_5_1_0_rot" x="180.0*1" y="0" z="0" unit="deg"/>
+	<position name="ssdsensor_5_1_1_pos" x="0" y="18.23" z="(1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_5_1_1_pos" x="0" y="18.23" z="1*ssdD0_thick+(1-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_5_1_1_rot" x="180.0*1" y="0" z="180" unit="deg"/>
+	<position name="ssdsensor_5_2_0_pos" x="12.92" y="-12.92" z="0.5*ssdD0_thick+ssd_bkpln_thick+0.5*mount_thick+0"/>
+	<position name="ssd_bkpln_5_2_0_pos" x="12.92" y="-12.92" z="0.5*ssd_bkpln_thick+0.5*mount_thick+0"/>
+	<rotation name="ssdsensor_5_2_0_rot" x="180.0*1" y="0" z="45" unit="deg"/>
+	<position name="ssdsensor_5_2_1_pos" x="-12.92" y="12.92" z="0.5*ssdD0_thick+ssd_bkpln_thick+0.5*mount_thick+0"/>
+	<position name="ssd_bkpln_5_2_1_pos" x="-12.92" y="12.92" z="0.5*ssd_bkpln_thick+0.5*mount_thick+0"/>
+	<rotation name="ssdsensor_5_2_1_rot" x="180.0*1" y="0" z="225" unit="deg"/>
+	<position name="ssdStation6_pos" x="0" y="0" z="ssdStation6_shift+ssdD0_thick-0.5*mount_thick"/>
+
+	<position name="ssdsensor_6_0_0_pos" x="-18.23" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_6_0_0_pos" x="-18.23" y="0" z="0*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_6_0_0_rot" x="180.0*0" y="0" z="270" unit="deg"/>
+	<position name="ssdsensor_6_0_1_pos" x="18.23" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_6_0_1_pos" x="18.23" y="0" z="0*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_6_0_1_rot" x="180.0*0" y="0" z="90" unit="deg"/>
+	<position name="ssdsensor_6_1_0_pos" x="0" y="-18.23" z="(1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_6_1_0_pos" x="0" y="-18.23" z="1*ssdD0_thick+(1-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_6_1_0_rot" x="180.0*1" y="0" z="0" unit="deg"/>
+	<position name="ssdsensor_6_1_1_pos" x="0" y="18.23" z="(1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_6_1_1_pos" x="0" y="18.23" z="1*ssdD0_thick+(1-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_6_1_1_rot" x="180.0*1" y="0" z="180" unit="deg"/>
+	<position name="ssdsensor_6_2_0_pos" x="12.92" y="-12.92" z="0.5*ssdD0_thick+ssd_bkpln_thick+0.5*mount_thick+0"/>
+	<position name="ssd_bkpln_6_2_0_pos" x="12.92" y="-12.92" z="0.5*ssd_bkpln_thick+0.5*mount_thick+0"/>
+	<rotation name="ssdsensor_6_2_0_rot" x="180.0*1" y="0" z="45" unit="deg"/>
+	<position name="ssdsensor_6_2_1_pos" x="-12.92" y="12.92" z="0.5*ssdD0_thick+ssd_bkpln_thick+0.5*mount_thick+0"/>
+	<position name="ssd_bkpln_6_2_1_pos" x="-12.92" y="12.92" z="0.5*ssd_bkpln_thick+0.5*mount_thick+0"/>
+	<rotation name="ssdsensor_6_2_1_rot" x="180.0*1" y="0" z="225" unit="deg"/>
+	<position name="ssdmount_local_0_0_pos" x="0" y="0" z="0"/>
+	<position name="ssdmount_0_0_pos" x="0" y="0" z="0+0.5*mount_thick"/>
+	<rotation name="ssdmount_0_0_rot" x="-0.44" y="-2.02" unit="deg"/>
+	<position name="ssdmount_local_1_0_pos" x="0" y="0" z="0"/>
+	<position name="ssdmount_1_0_pos" x="0" y="0" z="0+0.5*mount_thick"/>
+	<rotation name="ssdmount_1_0_rot" x="0.24" y="-1.26" unit="deg"/>
+	<position name="ssdmount_local_2_0_pos" x="0" y="0" z="0"/>
+	<position name="ssdmount_2_0_pos" x="0" y="0" z="0+0.5*mount_thick"/>
+	<rotation name="ssdmount_2_0_rot" x="0" y="0" unit="deg"/>
+	<position name="ssdmount_local_2_1_pos" x="0" y="0" z="0"/>
+	<position name="ssdmount_2_1_pos" x="0" y="0" z="10+0.5*mount_thick"/>
+	<rotation name="ssdmount_2_1_rot" x="0" y="0" unit="deg"/>
+	<position name="ssdmount_local_3_0_pos" x="0" y="0" z="0"/>
+	<position name="ssdmount_3_0_pos" x="0" y="0" z="0+0.5*mount_thick"/>
+	<rotation name="ssdmount_3_0_rot" x="0" y="0" unit="deg"/>
+	<position name="ssdmount_local_3_1_pos" x="0" y="0" z="0"/>
+	<position name="ssdmount_3_1_pos" x="0" y="0" z="10+0.5*mount_thick"/>
+	<rotation name="ssdmount_3_1_rot" x="0" y="0" unit="deg"/>
+	<position name="ssdmount_local_4_0_pos" x="0" y="0" z="0"/>
+	<position name="ssdmount_4_0_pos" x="0" y="0" z="0+0.5*mount_thick"/>
+	<rotation name="ssdmount_4_0_rot" x="0" y="0" unit="deg"/>
+	<position name="ssdmount_local_5_0_pos" x="0" y="0" z="0"/>
+	<position name="ssdmount_5_0_pos" x="0" y="0" z="0+0.5*mount_thick"/>
+	<rotation name="ssdmount_5_0_rot" x="0" y="0" unit="deg"/>
+	<position name="ssdmount_local_5_1_pos" x="0" y="0" z="0"/>
+	<position name="ssdmount_5_1_pos" x="0" y="0" z="10+0.5*mount_thick"/>
+	<rotation name="ssdmount_5_1_rot" x="0" y="0" unit="deg"/>
+	<position name="ssdmount_local_6_0_pos" x="0" y="0" z="0"/>
+	<position name="ssdmount_6_0_pos" x="0" y="0" z="0+0.5*mount_thick"/>
+	<rotation name="ssdmount_6_0_rot" x="-0.06" y="-1.49" unit="deg"/>
+	<position name="ssdmount_local_6_1_pos" x="0" y="0" z="0"/>
+	<position name="ssdmount_6_1_pos" x="0" y="0" z="10+0.5*mount_thick"/>
+	<rotation name="ssdmount_6_1_rot" x="-0.06" y="-1.49" unit="deg"/>
+
+	<position name="ssd_USMylarWindow_pos" x="0" y="0" z="-1*Mylar_shift"/>
+	<position name="ssd_DSMylarWindow_pos" x="0" y="0" z="Mylar_shift"/>
+
+	<position name="ssd_mount_u1_pos" x="70" y="0" z="0"/>
+	<rotation name="ssd_mount_u1_rot" y="-90" unit="deg"/>
+	<position name="ssd_mount_u2_pos" x="0" y="-70" z="0"/>
+	<rotation name="ssd_mount_u2_rot" y="-90" z="-90" unit="deg"/>
+	<rotation name="ssd_mount_u3_rot" z="90" unit="deg"/>
+	<position name="ssd_mount_u4_pos" x="80.1" y="-80.4"/>
+	<rotation name="ssd_mount_u4_rot" y="-90" z="135" unit="deg"/>
+	<position name="ssd_mount_out_pos1" z="0.5*mount_thick" unit="mm" />
+	<position name="ssd_mount_out_pos2" z="-0.5*mount_thick" unit="mm" />
+
+    <quantity name="ssdStationrotateLength" value="50" unit="mm" />
+	<quantity name="ssdStationrotateWidth" value="300" unit="mm" />
+	<quantity name="ssdStationrotateHeight" value="300" unit="mm" />
+	<quantity name="ssdStationdouble3plLength" value="100" unit="mm" />
+	<quantity name="ssdStationdouble3plWidth" value="450" unit="mm" />
+	<quantity name="ssdStationdouble3plHeight" value="450" unit="mm" />
+	<quantity name="ssdStationdouble2plLength" value="100" unit="mm" />
+	<quantity name="ssdStationdouble2plWidth" value="300" unit="mm" />
+	<quantity name="ssdStationdouble2plHeight" value="300" unit="mm" />
+
+	<position name="ssd_chan_0_pos" x="0" y="(-319.5+0)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_1_pos" x="0" y="(-319.5+1)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_2_pos" x="0" y="(-319.5+2)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_3_pos" x="0" y="(-319.5+3)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_4_pos" x="0" y="(-319.5+4)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_5_pos" x="0" y="(-319.5+5)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_6_pos" x="0" y="(-319.5+6)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_7_pos" x="0" y="(-319.5+7)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_8_pos" x="0" y="(-319.5+8)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_9_pos" x="0" y="(-319.5+9)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_10_pos" x="0" y="(-319.5+10)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_11_pos" x="0" y="(-319.5+11)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_12_pos" x="0" y="(-319.5+12)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_13_pos" x="0" y="(-319.5+13)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_14_pos" x="0" y="(-319.5+14)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_15_pos" x="0" y="(-319.5+15)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_16_pos" x="0" y="(-319.5+16)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_17_pos" x="0" y="(-319.5+17)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_18_pos" x="0" y="(-319.5+18)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_19_pos" x="0" y="(-319.5+19)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_20_pos" x="0" y="(-319.5+20)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_21_pos" x="0" y="(-319.5+21)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_22_pos" x="0" y="(-319.5+22)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_23_pos" x="0" y="(-319.5+23)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_24_pos" x="0" y="(-319.5+24)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_25_pos" x="0" y="(-319.5+25)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_26_pos" x="0" y="(-319.5+26)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_27_pos" x="0" y="(-319.5+27)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_28_pos" x="0" y="(-319.5+28)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_29_pos" x="0" y="(-319.5+29)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_30_pos" x="0" y="(-319.5+30)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_31_pos" x="0" y="(-319.5+31)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_32_pos" x="0" y="(-319.5+32)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_33_pos" x="0" y="(-319.5+33)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_34_pos" x="0" y="(-319.5+34)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_35_pos" x="0" y="(-319.5+35)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_36_pos" x="0" y="(-319.5+36)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_37_pos" x="0" y="(-319.5+37)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_38_pos" x="0" y="(-319.5+38)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_39_pos" x="0" y="(-319.5+39)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_40_pos" x="0" y="(-319.5+40)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_41_pos" x="0" y="(-319.5+41)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_42_pos" x="0" y="(-319.5+42)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_43_pos" x="0" y="(-319.5+43)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_44_pos" x="0" y="(-319.5+44)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_45_pos" x="0" y="(-319.5+45)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_46_pos" x="0" y="(-319.5+46)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_47_pos" x="0" y="(-319.5+47)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_48_pos" x="0" y="(-319.5+48)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_49_pos" x="0" y="(-319.5+49)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_50_pos" x="0" y="(-319.5+50)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_51_pos" x="0" y="(-319.5+51)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_52_pos" x="0" y="(-319.5+52)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_53_pos" x="0" y="(-319.5+53)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_54_pos" x="0" y="(-319.5+54)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_55_pos" x="0" y="(-319.5+55)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_56_pos" x="0" y="(-319.5+56)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_57_pos" x="0" y="(-319.5+57)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_58_pos" x="0" y="(-319.5+58)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_59_pos" x="0" y="(-319.5+59)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_60_pos" x="0" y="(-319.5+60)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_61_pos" x="0" y="(-319.5+61)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_62_pos" x="0" y="(-319.5+62)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_63_pos" x="0" y="(-319.5+63)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_64_pos" x="0" y="(-319.5+64)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_65_pos" x="0" y="(-319.5+65)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_66_pos" x="0" y="(-319.5+66)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_67_pos" x="0" y="(-319.5+67)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_68_pos" x="0" y="(-319.5+68)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_69_pos" x="0" y="(-319.5+69)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_70_pos" x="0" y="(-319.5+70)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_71_pos" x="0" y="(-319.5+71)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_72_pos" x="0" y="(-319.5+72)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_73_pos" x="0" y="(-319.5+73)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_74_pos" x="0" y="(-319.5+74)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_75_pos" x="0" y="(-319.5+75)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_76_pos" x="0" y="(-319.5+76)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_77_pos" x="0" y="(-319.5+77)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_78_pos" x="0" y="(-319.5+78)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_79_pos" x="0" y="(-319.5+79)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_80_pos" x="0" y="(-319.5+80)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_81_pos" x="0" y="(-319.5+81)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_82_pos" x="0" y="(-319.5+82)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_83_pos" x="0" y="(-319.5+83)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_84_pos" x="0" y="(-319.5+84)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_85_pos" x="0" y="(-319.5+85)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_86_pos" x="0" y="(-319.5+86)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_87_pos" x="0" y="(-319.5+87)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_88_pos" x="0" y="(-319.5+88)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_89_pos" x="0" y="(-319.5+89)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_90_pos" x="0" y="(-319.5+90)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_91_pos" x="0" y="(-319.5+91)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_92_pos" x="0" y="(-319.5+92)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_93_pos" x="0" y="(-319.5+93)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_94_pos" x="0" y="(-319.5+94)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_95_pos" x="0" y="(-319.5+95)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_96_pos" x="0" y="(-319.5+96)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_97_pos" x="0" y="(-319.5+97)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_98_pos" x="0" y="(-319.5+98)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_99_pos" x="0" y="(-319.5+99)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_100_pos" x="0" y="(-319.5+100)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_101_pos" x="0" y="(-319.5+101)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_102_pos" x="0" y="(-319.5+102)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_103_pos" x="0" y="(-319.5+103)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_104_pos" x="0" y="(-319.5+104)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_105_pos" x="0" y="(-319.5+105)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_106_pos" x="0" y="(-319.5+106)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_107_pos" x="0" y="(-319.5+107)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_108_pos" x="0" y="(-319.5+108)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_109_pos" x="0" y="(-319.5+109)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_110_pos" x="0" y="(-319.5+110)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_111_pos" x="0" y="(-319.5+111)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_112_pos" x="0" y="(-319.5+112)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_113_pos" x="0" y="(-319.5+113)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_114_pos" x="0" y="(-319.5+114)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_115_pos" x="0" y="(-319.5+115)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_116_pos" x="0" y="(-319.5+116)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_117_pos" x="0" y="(-319.5+117)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_118_pos" x="0" y="(-319.5+118)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_119_pos" x="0" y="(-319.5+119)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_120_pos" x="0" y="(-319.5+120)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_121_pos" x="0" y="(-319.5+121)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_122_pos" x="0" y="(-319.5+122)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_123_pos" x="0" y="(-319.5+123)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_124_pos" x="0" y="(-319.5+124)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_125_pos" x="0" y="(-319.5+125)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_126_pos" x="0" y="(-319.5+126)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_127_pos" x="0" y="(-319.5+127)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_128_pos" x="0" y="(-319.5+128)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_129_pos" x="0" y="(-319.5+129)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_130_pos" x="0" y="(-319.5+130)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_131_pos" x="0" y="(-319.5+131)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_132_pos" x="0" y="(-319.5+132)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_133_pos" x="0" y="(-319.5+133)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_134_pos" x="0" y="(-319.5+134)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_135_pos" x="0" y="(-319.5+135)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_136_pos" x="0" y="(-319.5+136)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_137_pos" x="0" y="(-319.5+137)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_138_pos" x="0" y="(-319.5+138)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_139_pos" x="0" y="(-319.5+139)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_140_pos" x="0" y="(-319.5+140)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_141_pos" x="0" y="(-319.5+141)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_142_pos" x="0" y="(-319.5+142)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_143_pos" x="0" y="(-319.5+143)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_144_pos" x="0" y="(-319.5+144)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_145_pos" x="0" y="(-319.5+145)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_146_pos" x="0" y="(-319.5+146)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_147_pos" x="0" y="(-319.5+147)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_148_pos" x="0" y="(-319.5+148)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_149_pos" x="0" y="(-319.5+149)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_150_pos" x="0" y="(-319.5+150)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_151_pos" x="0" y="(-319.5+151)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_152_pos" x="0" y="(-319.5+152)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_153_pos" x="0" y="(-319.5+153)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_154_pos" x="0" y="(-319.5+154)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_155_pos" x="0" y="(-319.5+155)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_156_pos" x="0" y="(-319.5+156)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_157_pos" x="0" y="(-319.5+157)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_158_pos" x="0" y="(-319.5+158)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_159_pos" x="0" y="(-319.5+159)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_160_pos" x="0" y="(-319.5+160)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_161_pos" x="0" y="(-319.5+161)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_162_pos" x="0" y="(-319.5+162)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_163_pos" x="0" y="(-319.5+163)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_164_pos" x="0" y="(-319.5+164)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_165_pos" x="0" y="(-319.5+165)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_166_pos" x="0" y="(-319.5+166)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_167_pos" x="0" y="(-319.5+167)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_168_pos" x="0" y="(-319.5+168)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_169_pos" x="0" y="(-319.5+169)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_170_pos" x="0" y="(-319.5+170)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_171_pos" x="0" y="(-319.5+171)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_172_pos" x="0" y="(-319.5+172)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_173_pos" x="0" y="(-319.5+173)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_174_pos" x="0" y="(-319.5+174)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_175_pos" x="0" y="(-319.5+175)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_176_pos" x="0" y="(-319.5+176)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_177_pos" x="0" y="(-319.5+177)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_178_pos" x="0" y="(-319.5+178)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_179_pos" x="0" y="(-319.5+179)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_180_pos" x="0" y="(-319.5+180)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_181_pos" x="0" y="(-319.5+181)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_182_pos" x="0" y="(-319.5+182)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_183_pos" x="0" y="(-319.5+183)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_184_pos" x="0" y="(-319.5+184)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_185_pos" x="0" y="(-319.5+185)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_186_pos" x="0" y="(-319.5+186)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_187_pos" x="0" y="(-319.5+187)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_188_pos" x="0" y="(-319.5+188)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_189_pos" x="0" y="(-319.5+189)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_190_pos" x="0" y="(-319.5+190)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_191_pos" x="0" y="(-319.5+191)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_192_pos" x="0" y="(-319.5+192)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_193_pos" x="0" y="(-319.5+193)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_194_pos" x="0" y="(-319.5+194)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_195_pos" x="0" y="(-319.5+195)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_196_pos" x="0" y="(-319.5+196)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_197_pos" x="0" y="(-319.5+197)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_198_pos" x="0" y="(-319.5+198)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_199_pos" x="0" y="(-319.5+199)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_200_pos" x="0" y="(-319.5+200)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_201_pos" x="0" y="(-319.5+201)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_202_pos" x="0" y="(-319.5+202)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_203_pos" x="0" y="(-319.5+203)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_204_pos" x="0" y="(-319.5+204)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_205_pos" x="0" y="(-319.5+205)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_206_pos" x="0" y="(-319.5+206)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_207_pos" x="0" y="(-319.5+207)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_208_pos" x="0" y="(-319.5+208)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_209_pos" x="0" y="(-319.5+209)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_210_pos" x="0" y="(-319.5+210)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_211_pos" x="0" y="(-319.5+211)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_212_pos" x="0" y="(-319.5+212)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_213_pos" x="0" y="(-319.5+213)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_214_pos" x="0" y="(-319.5+214)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_215_pos" x="0" y="(-319.5+215)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_216_pos" x="0" y="(-319.5+216)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_217_pos" x="0" y="(-319.5+217)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_218_pos" x="0" y="(-319.5+218)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_219_pos" x="0" y="(-319.5+219)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_220_pos" x="0" y="(-319.5+220)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_221_pos" x="0" y="(-319.5+221)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_222_pos" x="0" y="(-319.5+222)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_223_pos" x="0" y="(-319.5+223)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_224_pos" x="0" y="(-319.5+224)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_225_pos" x="0" y="(-319.5+225)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_226_pos" x="0" y="(-319.5+226)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_227_pos" x="0" y="(-319.5+227)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_228_pos" x="0" y="(-319.5+228)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_229_pos" x="0" y="(-319.5+229)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_230_pos" x="0" y="(-319.5+230)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_231_pos" x="0" y="(-319.5+231)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_232_pos" x="0" y="(-319.5+232)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_233_pos" x="0" y="(-319.5+233)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_234_pos" x="0" y="(-319.5+234)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_235_pos" x="0" y="(-319.5+235)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_236_pos" x="0" y="(-319.5+236)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_237_pos" x="0" y="(-319.5+237)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_238_pos" x="0" y="(-319.5+238)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_239_pos" x="0" y="(-319.5+239)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_240_pos" x="0" y="(-319.5+240)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_241_pos" x="0" y="(-319.5+241)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_242_pos" x="0" y="(-319.5+242)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_243_pos" x="0" y="(-319.5+243)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_244_pos" x="0" y="(-319.5+244)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_245_pos" x="0" y="(-319.5+245)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_246_pos" x="0" y="(-319.5+246)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_247_pos" x="0" y="(-319.5+247)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_248_pos" x="0" y="(-319.5+248)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_249_pos" x="0" y="(-319.5+249)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_250_pos" x="0" y="(-319.5+250)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_251_pos" x="0" y="(-319.5+251)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_252_pos" x="0" y="(-319.5+252)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_253_pos" x="0" y="(-319.5+253)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_254_pos" x="0" y="(-319.5+254)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_255_pos" x="0" y="(-319.5+255)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_256_pos" x="0" y="(-319.5+256)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_257_pos" x="0" y="(-319.5+257)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_258_pos" x="0" y="(-319.5+258)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_259_pos" x="0" y="(-319.5+259)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_260_pos" x="0" y="(-319.5+260)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_261_pos" x="0" y="(-319.5+261)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_262_pos" x="0" y="(-319.5+262)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_263_pos" x="0" y="(-319.5+263)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_264_pos" x="0" y="(-319.5+264)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_265_pos" x="0" y="(-319.5+265)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_266_pos" x="0" y="(-319.5+266)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_267_pos" x="0" y="(-319.5+267)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_268_pos" x="0" y="(-319.5+268)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_269_pos" x="0" y="(-319.5+269)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_270_pos" x="0" y="(-319.5+270)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_271_pos" x="0" y="(-319.5+271)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_272_pos" x="0" y="(-319.5+272)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_273_pos" x="0" y="(-319.5+273)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_274_pos" x="0" y="(-319.5+274)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_275_pos" x="0" y="(-319.5+275)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_276_pos" x="0" y="(-319.5+276)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_277_pos" x="0" y="(-319.5+277)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_278_pos" x="0" y="(-319.5+278)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_279_pos" x="0" y="(-319.5+279)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_280_pos" x="0" y="(-319.5+280)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_281_pos" x="0" y="(-319.5+281)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_282_pos" x="0" y="(-319.5+282)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_283_pos" x="0" y="(-319.5+283)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_284_pos" x="0" y="(-319.5+284)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_285_pos" x="0" y="(-319.5+285)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_286_pos" x="0" y="(-319.5+286)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_287_pos" x="0" y="(-319.5+287)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_288_pos" x="0" y="(-319.5+288)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_289_pos" x="0" y="(-319.5+289)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_290_pos" x="0" y="(-319.5+290)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_291_pos" x="0" y="(-319.5+291)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_292_pos" x="0" y="(-319.5+292)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_293_pos" x="0" y="(-319.5+293)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_294_pos" x="0" y="(-319.5+294)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_295_pos" x="0" y="(-319.5+295)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_296_pos" x="0" y="(-319.5+296)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_297_pos" x="0" y="(-319.5+297)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_298_pos" x="0" y="(-319.5+298)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_299_pos" x="0" y="(-319.5+299)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_300_pos" x="0" y="(-319.5+300)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_301_pos" x="0" y="(-319.5+301)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_302_pos" x="0" y="(-319.5+302)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_303_pos" x="0" y="(-319.5+303)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_304_pos" x="0" y="(-319.5+304)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_305_pos" x="0" y="(-319.5+305)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_306_pos" x="0" y="(-319.5+306)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_307_pos" x="0" y="(-319.5+307)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_308_pos" x="0" y="(-319.5+308)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_309_pos" x="0" y="(-319.5+309)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_310_pos" x="0" y="(-319.5+310)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_311_pos" x="0" y="(-319.5+311)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_312_pos" x="0" y="(-319.5+312)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_313_pos" x="0" y="(-319.5+313)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_314_pos" x="0" y="(-319.5+314)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_315_pos" x="0" y="(-319.5+315)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_316_pos" x="0" y="(-319.5+316)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_317_pos" x="0" y="(-319.5+317)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_318_pos" x="0" y="(-319.5+318)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_319_pos" x="0" y="(-319.5+319)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_320_pos" x="0" y="(-319.5+320)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_321_pos" x="0" y="(-319.5+321)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_322_pos" x="0" y="(-319.5+322)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_323_pos" x="0" y="(-319.5+323)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_324_pos" x="0" y="(-319.5+324)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_325_pos" x="0" y="(-319.5+325)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_326_pos" x="0" y="(-319.5+326)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_327_pos" x="0" y="(-319.5+327)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_328_pos" x="0" y="(-319.5+328)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_329_pos" x="0" y="(-319.5+329)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_330_pos" x="0" y="(-319.5+330)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_331_pos" x="0" y="(-319.5+331)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_332_pos" x="0" y="(-319.5+332)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_333_pos" x="0" y="(-319.5+333)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_334_pos" x="0" y="(-319.5+334)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_335_pos" x="0" y="(-319.5+335)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_336_pos" x="0" y="(-319.5+336)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_337_pos" x="0" y="(-319.5+337)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_338_pos" x="0" y="(-319.5+338)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_339_pos" x="0" y="(-319.5+339)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_340_pos" x="0" y="(-319.5+340)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_341_pos" x="0" y="(-319.5+341)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_342_pos" x="0" y="(-319.5+342)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_343_pos" x="0" y="(-319.5+343)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_344_pos" x="0" y="(-319.5+344)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_345_pos" x="0" y="(-319.5+345)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_346_pos" x="0" y="(-319.5+346)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_347_pos" x="0" y="(-319.5+347)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_348_pos" x="0" y="(-319.5+348)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_349_pos" x="0" y="(-319.5+349)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_350_pos" x="0" y="(-319.5+350)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_351_pos" x="0" y="(-319.5+351)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_352_pos" x="0" y="(-319.5+352)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_353_pos" x="0" y="(-319.5+353)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_354_pos" x="0" y="(-319.5+354)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_355_pos" x="0" y="(-319.5+355)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_356_pos" x="0" y="(-319.5+356)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_357_pos" x="0" y="(-319.5+357)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_358_pos" x="0" y="(-319.5+358)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_359_pos" x="0" y="(-319.5+359)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_360_pos" x="0" y="(-319.5+360)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_361_pos" x="0" y="(-319.5+361)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_362_pos" x="0" y="(-319.5+362)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_363_pos" x="0" y="(-319.5+363)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_364_pos" x="0" y="(-319.5+364)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_365_pos" x="0" y="(-319.5+365)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_366_pos" x="0" y="(-319.5+366)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_367_pos" x="0" y="(-319.5+367)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_368_pos" x="0" y="(-319.5+368)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_369_pos" x="0" y="(-319.5+369)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_370_pos" x="0" y="(-319.5+370)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_371_pos" x="0" y="(-319.5+371)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_372_pos" x="0" y="(-319.5+372)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_373_pos" x="0" y="(-319.5+373)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_374_pos" x="0" y="(-319.5+374)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_375_pos" x="0" y="(-319.5+375)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_376_pos" x="0" y="(-319.5+376)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_377_pos" x="0" y="(-319.5+377)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_378_pos" x="0" y="(-319.5+378)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_379_pos" x="0" y="(-319.5+379)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_380_pos" x="0" y="(-319.5+380)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_381_pos" x="0" y="(-319.5+381)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_382_pos" x="0" y="(-319.5+382)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_383_pos" x="0" y="(-319.5+383)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_384_pos" x="0" y="(-319.5+384)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_385_pos" x="0" y="(-319.5+385)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_386_pos" x="0" y="(-319.5+386)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_387_pos" x="0" y="(-319.5+387)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_388_pos" x="0" y="(-319.5+388)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_389_pos" x="0" y="(-319.5+389)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_390_pos" x="0" y="(-319.5+390)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_391_pos" x="0" y="(-319.5+391)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_392_pos" x="0" y="(-319.5+392)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_393_pos" x="0" y="(-319.5+393)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_394_pos" x="0" y="(-319.5+394)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_395_pos" x="0" y="(-319.5+395)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_396_pos" x="0" y="(-319.5+396)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_397_pos" x="0" y="(-319.5+397)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_398_pos" x="0" y="(-319.5+398)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_399_pos" x="0" y="(-319.5+399)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_400_pos" x="0" y="(-319.5+400)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_401_pos" x="0" y="(-319.5+401)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_402_pos" x="0" y="(-319.5+402)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_403_pos" x="0" y="(-319.5+403)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_404_pos" x="0" y="(-319.5+404)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_405_pos" x="0" y="(-319.5+405)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_406_pos" x="0" y="(-319.5+406)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_407_pos" x="0" y="(-319.5+407)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_408_pos" x="0" y="(-319.5+408)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_409_pos" x="0" y="(-319.5+409)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_410_pos" x="0" y="(-319.5+410)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_411_pos" x="0" y="(-319.5+411)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_412_pos" x="0" y="(-319.5+412)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_413_pos" x="0" y="(-319.5+413)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_414_pos" x="0" y="(-319.5+414)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_415_pos" x="0" y="(-319.5+415)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_416_pos" x="0" y="(-319.5+416)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_417_pos" x="0" y="(-319.5+417)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_418_pos" x="0" y="(-319.5+418)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_419_pos" x="0" y="(-319.5+419)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_420_pos" x="0" y="(-319.5+420)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_421_pos" x="0" y="(-319.5+421)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_422_pos" x="0" y="(-319.5+422)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_423_pos" x="0" y="(-319.5+423)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_424_pos" x="0" y="(-319.5+424)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_425_pos" x="0" y="(-319.5+425)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_426_pos" x="0" y="(-319.5+426)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_427_pos" x="0" y="(-319.5+427)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_428_pos" x="0" y="(-319.5+428)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_429_pos" x="0" y="(-319.5+429)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_430_pos" x="0" y="(-319.5+430)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_431_pos" x="0" y="(-319.5+431)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_432_pos" x="0" y="(-319.5+432)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_433_pos" x="0" y="(-319.5+433)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_434_pos" x="0" y="(-319.5+434)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_435_pos" x="0" y="(-319.5+435)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_436_pos" x="0" y="(-319.5+436)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_437_pos" x="0" y="(-319.5+437)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_438_pos" x="0" y="(-319.5+438)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_439_pos" x="0" y="(-319.5+439)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_440_pos" x="0" y="(-319.5+440)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_441_pos" x="0" y="(-319.5+441)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_442_pos" x="0" y="(-319.5+442)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_443_pos" x="0" y="(-319.5+443)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_444_pos" x="0" y="(-319.5+444)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_445_pos" x="0" y="(-319.5+445)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_446_pos" x="0" y="(-319.5+446)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_447_pos" x="0" y="(-319.5+447)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_448_pos" x="0" y="(-319.5+448)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_449_pos" x="0" y="(-319.5+449)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_450_pos" x="0" y="(-319.5+450)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_451_pos" x="0" y="(-319.5+451)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_452_pos" x="0" y="(-319.5+452)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_453_pos" x="0" y="(-319.5+453)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_454_pos" x="0" y="(-319.5+454)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_455_pos" x="0" y="(-319.5+455)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_456_pos" x="0" y="(-319.5+456)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_457_pos" x="0" y="(-319.5+457)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_458_pos" x="0" y="(-319.5+458)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_459_pos" x="0" y="(-319.5+459)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_460_pos" x="0" y="(-319.5+460)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_461_pos" x="0" y="(-319.5+461)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_462_pos" x="0" y="(-319.5+462)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_463_pos" x="0" y="(-319.5+463)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_464_pos" x="0" y="(-319.5+464)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_465_pos" x="0" y="(-319.5+465)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_466_pos" x="0" y="(-319.5+466)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_467_pos" x="0" y="(-319.5+467)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_468_pos" x="0" y="(-319.5+468)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_469_pos" x="0" y="(-319.5+469)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_470_pos" x="0" y="(-319.5+470)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_471_pos" x="0" y="(-319.5+471)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_472_pos" x="0" y="(-319.5+472)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_473_pos" x="0" y="(-319.5+473)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_474_pos" x="0" y="(-319.5+474)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_475_pos" x="0" y="(-319.5+475)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_476_pos" x="0" y="(-319.5+476)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_477_pos" x="0" y="(-319.5+477)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_478_pos" x="0" y="(-319.5+478)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_479_pos" x="0" y="(-319.5+479)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_480_pos" x="0" y="(-319.5+480)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_481_pos" x="0" y="(-319.5+481)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_482_pos" x="0" y="(-319.5+482)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_483_pos" x="0" y="(-319.5+483)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_484_pos" x="0" y="(-319.5+484)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_485_pos" x="0" y="(-319.5+485)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_486_pos" x="0" y="(-319.5+486)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_487_pos" x="0" y="(-319.5+487)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_488_pos" x="0" y="(-319.5+488)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_489_pos" x="0" y="(-319.5+489)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_490_pos" x="0" y="(-319.5+490)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_491_pos" x="0" y="(-319.5+491)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_492_pos" x="0" y="(-319.5+492)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_493_pos" x="0" y="(-319.5+493)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_494_pos" x="0" y="(-319.5+494)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_495_pos" x="0" y="(-319.5+495)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_496_pos" x="0" y="(-319.5+496)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_497_pos" x="0" y="(-319.5+497)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_498_pos" x="0" y="(-319.5+498)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_499_pos" x="0" y="(-319.5+499)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_500_pos" x="0" y="(-319.5+500)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_501_pos" x="0" y="(-319.5+501)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_502_pos" x="0" y="(-319.5+502)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_503_pos" x="0" y="(-319.5+503)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_504_pos" x="0" y="(-319.5+504)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_505_pos" x="0" y="(-319.5+505)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_506_pos" x="0" y="(-319.5+506)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_507_pos" x="0" y="(-319.5+507)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_508_pos" x="0" y="(-319.5+508)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_509_pos" x="0" y="(-319.5+509)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_510_pos" x="0" y="(-319.5+510)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_511_pos" x="0" y="(-319.5+511)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_512_pos" x="0" y="(-319.5+512)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_513_pos" x="0" y="(-319.5+513)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_514_pos" x="0" y="(-319.5+514)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_515_pos" x="0" y="(-319.5+515)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_516_pos" x="0" y="(-319.5+516)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_517_pos" x="0" y="(-319.5+517)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_518_pos" x="0" y="(-319.5+518)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_519_pos" x="0" y="(-319.5+519)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_520_pos" x="0" y="(-319.5+520)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_521_pos" x="0" y="(-319.5+521)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_522_pos" x="0" y="(-319.5+522)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_523_pos" x="0" y="(-319.5+523)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_524_pos" x="0" y="(-319.5+524)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_525_pos" x="0" y="(-319.5+525)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_526_pos" x="0" y="(-319.5+526)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_527_pos" x="0" y="(-319.5+527)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_528_pos" x="0" y="(-319.5+528)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_529_pos" x="0" y="(-319.5+529)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_530_pos" x="0" y="(-319.5+530)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_531_pos" x="0" y="(-319.5+531)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_532_pos" x="0" y="(-319.5+532)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_533_pos" x="0" y="(-319.5+533)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_534_pos" x="0" y="(-319.5+534)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_535_pos" x="0" y="(-319.5+535)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_536_pos" x="0" y="(-319.5+536)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_537_pos" x="0" y="(-319.5+537)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_538_pos" x="0" y="(-319.5+538)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_539_pos" x="0" y="(-319.5+539)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_540_pos" x="0" y="(-319.5+540)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_541_pos" x="0" y="(-319.5+541)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_542_pos" x="0" y="(-319.5+542)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_543_pos" x="0" y="(-319.5+543)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_544_pos" x="0" y="(-319.5+544)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_545_pos" x="0" y="(-319.5+545)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_546_pos" x="0" y="(-319.5+546)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_547_pos" x="0" y="(-319.5+547)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_548_pos" x="0" y="(-319.5+548)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_549_pos" x="0" y="(-319.5+549)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_550_pos" x="0" y="(-319.5+550)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_551_pos" x="0" y="(-319.5+551)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_552_pos" x="0" y="(-319.5+552)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_553_pos" x="0" y="(-319.5+553)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_554_pos" x="0" y="(-319.5+554)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_555_pos" x="0" y="(-319.5+555)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_556_pos" x="0" y="(-319.5+556)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_557_pos" x="0" y="(-319.5+557)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_558_pos" x="0" y="(-319.5+558)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_559_pos" x="0" y="(-319.5+559)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_560_pos" x="0" y="(-319.5+560)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_561_pos" x="0" y="(-319.5+561)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_562_pos" x="0" y="(-319.5+562)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_563_pos" x="0" y="(-319.5+563)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_564_pos" x="0" y="(-319.5+564)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_565_pos" x="0" y="(-319.5+565)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_566_pos" x="0" y="(-319.5+566)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_567_pos" x="0" y="(-319.5+567)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_568_pos" x="0" y="(-319.5+568)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_569_pos" x="0" y="(-319.5+569)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_570_pos" x="0" y="(-319.5+570)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_571_pos" x="0" y="(-319.5+571)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_572_pos" x="0" y="(-319.5+572)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_573_pos" x="0" y="(-319.5+573)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_574_pos" x="0" y="(-319.5+574)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_575_pos" x="0" y="(-319.5+575)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_576_pos" x="0" y="(-319.5+576)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_577_pos" x="0" y="(-319.5+577)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_578_pos" x="0" y="(-319.5+578)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_579_pos" x="0" y="(-319.5+579)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_580_pos" x="0" y="(-319.5+580)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_581_pos" x="0" y="(-319.5+581)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_582_pos" x="0" y="(-319.5+582)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_583_pos" x="0" y="(-319.5+583)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_584_pos" x="0" y="(-319.5+584)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_585_pos" x="0" y="(-319.5+585)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_586_pos" x="0" y="(-319.5+586)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_587_pos" x="0" y="(-319.5+587)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_588_pos" x="0" y="(-319.5+588)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_589_pos" x="0" y="(-319.5+589)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_590_pos" x="0" y="(-319.5+590)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_591_pos" x="0" y="(-319.5+591)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_592_pos" x="0" y="(-319.5+592)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_593_pos" x="0" y="(-319.5+593)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_594_pos" x="0" y="(-319.5+594)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_595_pos" x="0" y="(-319.5+595)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_596_pos" x="0" y="(-319.5+596)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_597_pos" x="0" y="(-319.5+597)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_598_pos" x="0" y="(-319.5+598)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_599_pos" x="0" y="(-319.5+599)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_600_pos" x="0" y="(-319.5+600)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_601_pos" x="0" y="(-319.5+601)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_602_pos" x="0" y="(-319.5+602)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_603_pos" x="0" y="(-319.5+603)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_604_pos" x="0" y="(-319.5+604)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_605_pos" x="0" y="(-319.5+605)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_606_pos" x="0" y="(-319.5+606)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_607_pos" x="0" y="(-319.5+607)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_608_pos" x="0" y="(-319.5+608)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_609_pos" x="0" y="(-319.5+609)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_610_pos" x="0" y="(-319.5+610)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_611_pos" x="0" y="(-319.5+611)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_612_pos" x="0" y="(-319.5+612)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_613_pos" x="0" y="(-319.5+613)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_614_pos" x="0" y="(-319.5+614)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_615_pos" x="0" y="(-319.5+615)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_616_pos" x="0" y="(-319.5+616)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_617_pos" x="0" y="(-319.5+617)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_618_pos" x="0" y="(-319.5+618)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_619_pos" x="0" y="(-319.5+619)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_620_pos" x="0" y="(-319.5+620)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_621_pos" x="0" y="(-319.5+621)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_622_pos" x="0" y="(-319.5+622)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_623_pos" x="0" y="(-319.5+623)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_624_pos" x="0" y="(-319.5+624)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_625_pos" x="0" y="(-319.5+625)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_626_pos" x="0" y="(-319.5+626)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_627_pos" x="0" y="(-319.5+627)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_628_pos" x="0" y="(-319.5+628)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_629_pos" x="0" y="(-319.5+629)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_630_pos" x="0" y="(-319.5+630)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_631_pos" x="0" y="(-319.5+631)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_632_pos" x="0" y="(-319.5+632)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_633_pos" x="0" y="(-319.5+633)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_634_pos" x="0" y="(-319.5+634)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_635_pos" x="0" y="(-319.5+635)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_636_pos" x="0" y="(-319.5+636)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_637_pos" x="0" y="(-319.5+637)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_638_pos" x="0" y="(-319.5+638)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_639_pos" x="0" y="(-319.5+639)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<!-- ABOVE IS FOR SSD -->
+	<!-- BELOW IS FOR ARICH -->
+
+	<quantity name="arich_shift" value="1862.82" unit="mm"/>
+	<quantity name="arich_thick" value="280.0" unit="mm"/>
+	<quantity name="arich_width" value="365.0" unit="mm"/>
+	<quantity name="arich_height" value="365.0" unit="mm"/>
+
+	<position name="arich_pos" x="0" y="0" z="arich_shift+0.5*arich_thick" />
+	<quantity name="aerogel_thick0" value="18.9" unit="mm"/>
+	<quantity name="aerogel_thick1" value="20.4" unit="mm"/>
+	<quantity name="aerogel_size" value="93.0" unit="mm"/>
+	<quantity name="aerogel_shift" value="43.0" unit="mm"/>
+	 
+	<position name="aerogel_pos0" x="0" y="0" z="aerogel_shift-0.5*arich_thick+0.5*aerogel_thick0" />
+	<position name="aerogel_pos1" x="0" y="0" z="aerogel_shift-0.5*arich_thick+aerogel_thick0+0.5*aerogel_thick1" />
+
+	<quantity name="mPMT_thick" value="16.4" unit="mm"/>
+	<quantity name="mPMT_size" value="49.3" unit="mm"/>
+	<quantity name="mPMT_gap" value="5.4" unit="mm"/>
+	<quantity name="manode_size" value="6.0" unit="mm"/>
+	<quantity name="mPMT_shift" value="103.0" unit="mm"/>
+
+	<position name="mPMT0_0_anode0_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode0_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode0_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode0_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode0_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode0_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode0_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode0_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode1_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode1_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode1_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode1_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode1_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode1_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode1_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode1_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode2_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode2_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode2_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode2_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode2_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode2_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode2_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode2_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode3_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode3_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode3_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode3_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode3_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode3_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode3_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode3_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode4_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode4_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode4_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode4_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode4_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode4_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode4_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode4_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode5_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode5_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode5_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode5_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode5_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode5_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode5_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode5_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode6_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode6_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode6_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode6_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode6_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode6_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode6_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode6_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode7_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode7_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode7_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode7_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode7_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode7_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode7_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode7_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode0_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode0_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode0_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode0_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode0_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode0_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode0_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode0_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode1_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode1_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode1_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode1_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode1_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode1_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode1_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode1_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode2_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode2_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode2_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode2_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode2_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode2_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode2_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode2_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode3_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode3_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode3_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode3_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode3_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode3_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode3_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode3_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode4_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode4_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode4_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode4_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode4_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode4_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode4_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode4_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode5_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode5_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode5_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode5_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode5_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode5_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode5_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode5_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode6_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode6_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode6_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode6_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode6_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode6_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode6_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode6_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode7_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode7_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode7_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode7_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode7_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode7_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode7_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode7_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode0_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode0_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode0_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode0_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode0_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode0_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode0_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode0_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode1_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode1_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode1_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode1_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode1_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode1_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode1_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode1_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode2_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode2_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode2_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode2_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode2_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode2_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode2_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode2_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode3_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode3_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode3_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode3_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode3_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode3_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode3_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode3_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode4_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode4_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode4_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode4_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode4_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode4_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode4_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode4_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode5_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode5_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode5_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode5_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode5_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode5_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode5_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode5_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode6_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode6_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode6_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode6_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode6_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode6_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode6_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode6_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode7_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode7_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode7_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode7_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode7_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode7_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode7_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode7_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode0_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode0_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode0_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode0_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode0_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode0_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode0_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode0_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode1_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode1_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode1_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode1_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode1_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode1_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode1_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode1_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode2_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode2_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode2_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode2_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode2_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode2_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode2_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode2_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode3_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode3_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode3_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode3_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode3_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode3_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode3_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode3_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode4_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode4_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode4_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode4_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode4_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode4_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode4_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode4_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode5_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode5_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode5_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode5_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode5_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode5_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode5_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode5_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode6_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode6_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode6_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode6_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode6_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode6_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode6_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode6_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode7_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode7_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode7_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode7_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode7_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode7_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode7_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode7_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode0_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode0_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode0_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode0_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode0_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode0_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode0_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode0_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode1_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode1_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode1_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode1_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode1_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode1_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode1_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode1_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode2_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode2_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode2_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode2_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode2_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode2_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode2_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode2_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode3_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode3_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode3_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode3_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode3_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode3_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode3_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode3_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode4_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode4_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode4_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode4_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode4_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode4_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode4_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode4_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode5_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode5_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode5_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode5_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode5_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode5_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode5_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode5_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode6_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode6_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode6_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode6_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode6_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode6_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode6_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode6_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode7_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode7_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode7_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode7_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode7_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode7_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode7_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode7_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode0_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode0_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode0_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode0_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode0_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode0_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode0_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode0_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode1_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode1_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode1_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode1_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode1_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode1_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode1_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode1_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode2_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode2_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode2_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode2_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode2_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode2_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode2_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode2_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode3_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode3_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode3_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode3_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode3_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode3_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode3_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode3_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode4_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode4_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode4_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode4_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode4_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode4_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode4_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode4_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode5_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode5_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode5_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode5_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode5_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode5_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode5_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode5_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode6_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode6_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode6_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode6_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode6_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode6_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode6_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode6_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode7_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode7_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode7_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode7_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode7_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode7_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode7_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode7_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode0_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode0_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode0_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode0_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode0_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode0_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode0_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode0_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode1_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode1_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode1_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode1_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode1_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode1_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode1_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode1_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode2_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode2_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode2_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode2_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode2_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode2_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode2_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode2_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode3_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode3_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode3_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode3_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode3_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode3_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode3_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode3_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode4_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode4_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode4_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode4_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode4_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode4_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode4_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode4_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode5_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode5_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode5_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode5_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode5_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode5_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode5_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode5_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode6_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode6_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode6_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode6_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode6_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode6_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode6_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode6_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode7_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode7_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode7_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode7_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode7_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode7_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode7_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode7_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode0_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode0_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode0_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode0_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode0_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode0_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode0_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode0_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode1_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode1_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode1_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode1_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode1_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode1_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode1_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode1_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode2_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode2_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode2_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode2_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode2_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode2_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode2_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode2_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode3_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode3_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode3_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode3_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode3_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode3_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode3_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode3_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode4_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode4_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode4_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode4_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode4_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode4_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode4_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode4_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode5_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode5_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode5_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode5_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode5_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode5_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode5_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode5_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode6_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode6_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode6_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode6_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode6_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode6_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode6_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode6_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode7_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode7_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode7_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode7_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode7_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode7_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode7_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode7_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode0_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode0_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode0_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode0_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode0_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode0_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode0_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode0_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode1_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode1_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode1_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode1_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode1_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode1_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode1_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode1_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode2_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode2_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode2_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode2_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode2_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode2_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode2_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode2_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode3_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode3_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode3_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode3_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode3_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode3_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode3_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode3_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode4_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode4_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode4_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode4_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode4_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode4_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode4_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode4_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode5_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode5_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode5_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode5_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode5_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode5_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode5_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode5_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode6_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode6_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode6_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode6_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode6_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode6_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode6_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode6_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode7_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode7_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode7_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode7_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode7_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode7_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode7_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode7_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+ 
+	<quantity name="PMTplate_thick" value="5.8" unit="mm"/>
+	<quantity name="PMTplate_size" value="195.7" unit="mm"/>
+
+	<position name="PMTplate_pos" x="0" y="0" z="mPMT_shift+mPMT_thick+0.5*PMTplate_thick" />
+	<!-- ABOVE IS FOR ARICH -->
+
+	 <!-- BELOW IS FOR RPC -->
+
+	 <quantity name="RPC_thick" value="54" unit="mm" />
+	 <quantity name="RPC_width" value="1066" unit="mm" />
+	 <quantity name="RPC_height" value="252" unit="mm" />
+	 <quantity name="RPC_volume_thick" value="200" unit="mm" />
+	 <quantity name="RPC0_shift" value="3953.38" unit="mm" />
+	 <quantity name="RPC1_shift" value="4050.39" unit="mm" />
+	 <quantity name="RPC_shift" value="4028.89" unit="mm" />
+
+	 <quantity name="RPC_Al_thick" value="1" unit="mm" />
+	 <quantity name="RPC_comb_thick" value="17" unit="mm" />
+	 <quantity name="RPC_PCB_thick" value="1" unit="mm" />
+	 <quantity name="RPC_acrylic_thick" value="1" unit="mm" />
+	 <quantity name="RPC_gas_width" value="960.5" unit="mm" />
+	 <quantity name="RPC_gas_height" value="250.5" unit="mm" />
+	 <quantity name="RPC_gas_thick" value="6" unit="mm" />
+
+	 <position name="RPC_pos" z="RPC_shift" unit="mm" />
+     <position name="RPC0_pos" z="RPC0_shift+0.5*RPC_thick-RPC_shift"/>
+     <position name="RPC0_Al0_pos" z="RPC_thick*(0-(2-1)*0.5)+RPC0_shift+0.5*RPC_thick-RPC_shift"/>
+     <position name="RPC0_Al1_pos" z="RPC_thick*(1-(2-1)*0.5)+RPC0_shift+0.5*RPC_thick-RPC_shift"/>
+     <position name="RPC1_pos" z="RPC1_shift+0.5*RPC_thick-RPC_shift"/>
+     <position name="RPC1_Al0_pos" z="RPC_thick*(0-(2-1)*0.5)+RPC1_shift+0.5*RPC_thick-RPC_shift"/>
+     <position name="RPC1_Al1_pos" z="RPC_thick*(1-(2-1)*0.5)+RPC1_shift+0.5*RPC_thick-RPC_shift"/>
+	 <!-- ABOVE IS FOR RPC -->
+
+	<!-- BELOW IS FOR LG -->
+
+    <quantity name="LG_length" value="340" unit="mm" />
+    <quantity name="LG_height" value="122" unit="mm" />
+    <quantity name="LG_width0" value="113" unit="mm" />
+    <quantity name="LG_width1" value="135" unit="mm" />
+    <quantity name="LG_width1T" value="145.4824" unit="mm" />
+    <quantity name="LG_angle" value="3.7074" unit="degree"/>
+    <quantity name="LG_TransHorOff_shift" value="2." unit="mm" />
+    <quantity name="LG_protrusion_thick" value="40" unit="mm" />
+    <quantity name="LG_PMTr" value="38" unit="mm" />
+    <quantity name="LG_PMTl" value="120" unit="mm" />
+
+    <position name="LG_trap_pos1" x="0" y="0" z="-0.5*(LG_TransHorOff_shift+LG_length+LG_protrusion_thick+LG_PMTl-LG_length)"/>
+	<position name="LG_protrusion_pos" x="0" y="0" z="LG_length-0.5*(LG_TransHorOff_shift+LG_length+LG_protrusion_thick+LG_PMTl)+0.5*LG_protrusion_thick"/>
+	<position name="LG_PMT_pos" x="0" y="0" z="LG_length-0.5*(LG_TransHorOff_shift+LG_length+LG_protrusion_thick+LG_PMTl)+LG_protrusion_thick+0.5*LG_PMTl"/>
+
+	<position name="LG_block00_pos" x="(0.5*(LG_width0+LG_width1T)+LG_TransHorOff_shift+Tolerance_space)" y="LG_height*(0-1)+2.5*(0-1)" z="0."/>
+	<position name="LG_block01_pos" x="0" y="LG_height*(0-1)+2.5*(0-1)" z="0"/>
+	<position name="LG_block02_pos" x="-(0.5*(LG_width0+LG_width1T)+LG_TransHorOff_shift+Tolerance_space)" y="LG_height*(0-1)+2.5*(0-1)" z="0."/>
+	<rotation name="LG_block00_rot" x="0" y="-1.0*LG_angle" z="0" />
+	<rotation name="LG_block01_rot" x="0" y="0" z="0" />
+	<rotation name="LG_block02_rot" x="0" y="LG_angle" z="0" />
+	<position name="LG_block10_pos" x="(0.5*(LG_width0+LG_width1T)+LG_TransHorOff_shift+Tolerance_space)" y="LG_height*(1-1)+2.5*(1-1)" z="0."/>
+	<position name="LG_block11_pos" x="0" y="LG_height*(1-1)+2.5*(1-1)" z="0"/>
+	<position name="LG_block12_pos" x="-(0.5*(LG_width0+LG_width1T)+LG_TransHorOff_shift+Tolerance_space)" y="LG_height*(1-1)+2.5*(1-1)" z="0."/>
+	<rotation name="LG_block10_rot" x="0" y="-1.0*LG_angle" z="0" />
+	<rotation name="LG_block11_rot" x="0" y="0" z="0" />
+	<rotation name="LG_block12_rot" x="0" y="LG_angle" z="0" />
+	<position name="LG_block20_pos" x="(0.5*(LG_width0+LG_width1T)+LG_TransHorOff_shift+Tolerance_space)" y="LG_height*(2-1)+2.5*(2-1)" z="0."/>
+	<position name="LG_block21_pos" x="0" y="LG_height*(2-1)+2.5*(2-1)" z="0"/>
+	<position name="LG_block22_pos" x="-(0.5*(LG_width0+LG_width1T)+LG_TransHorOff_shift+Tolerance_space)" y="LG_height*(2-1)+2.5*(2-1)" z="0."/>
+	<rotation name="LG_block20_rot" x="0" y="-1.0*LG_angle" z="0" />
+	<rotation name="LG_block21_rot" x="0" y="0" z="0" />
+	<rotation name="LG_block22_rot" x="0" y="LG_angle" z="0" />
+	<quantity name="calor_length" value="520" unit="mm" />
+	<quantity name="calor_height" value="380" unit="mm" />
+	<quantity name="calor_width" value="900" unit="mm" />
+    <quantity name="calor_shift" value="4286.4" unit="mm" />
+    <position name="calor_pos" x="0" y="0" z="calor_shift+calor_length*0.5"/>
+
+	 <!-- ABOVE IS FOR LG -->
+
+  
 
 	<!-- ********** Refractive index ********** -->
 

--- a/ConstBase/Geometry/phase1c_Empty_nomag.gdml
+++ b/ConstBase/Geometry/phase1c_Empty_nomag.gdml
@@ -8,6 +8,2145 @@
 --> 
 
 <define>
+	
+	<constant name="DEG2RAD" value="pi/180." />
+	<quantity name="world_size" value="10000." unit="mm"/>
+	<quantity name="Tolerance_space" value="1." unit="mm" />
+	<position name="center" x="0" y="0" z="0" unit="mm"/>
+	
+    <!-- BELOW IS FOR T0 -->
+		
+	<quantity name="T0_length" value="280.0" unit="mm"/>
+	<quantity name="T0_width" value="210.0" unit="mm"/>
+	<quantity name="T0_height" value="300.0" unit="mm"/>
+	<quantity name="T0_shift" value="-267.5" unit="mm"/>
+	<quantity name="T0_acrylic_shift" value="40.0" unit="mm"/>
+	<position name="T0_pos" z="T0_shift+T0_acrylic_shift"/>
+
+	<quantity name="T0_acrylic_length" value="150.0" unit="mm"/>
+	<quantity name="T0_acrylic_width" value="3.0" unit="mm"/>
+	<quantity name="T0_acrylic_height" value="3.0" unit="mm"/>
+		
+	<position name="T0_acrylic0_pos" x="T0_acrylic_width*(0-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*0"/>
+	<position name="T0_acrylic1_pos" x="T0_acrylic_width*(1-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*1"/>
+	<position name="T0_acrylic2_pos" x="T0_acrylic_width*(2-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*0"/>
+	<position name="T0_acrylic3_pos" x="T0_acrylic_width*(3-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*1"/>
+	<position name="T0_acrylic4_pos" x="T0_acrylic_width*(4-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*0"/>
+	<position name="T0_acrylic5_pos" x="T0_acrylic_width*(5-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*1"/>
+	<position name="T0_acrylic6_pos" x="T0_acrylic_width*(6-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*0"/>
+	<position name="T0_acrylic7_pos" x="T0_acrylic_width*(7-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*1"/>
+	<position name="T0_acrylic8_pos" x="T0_acrylic_width*(8-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*0"/>
+	<position name="T0_acrylic9_pos" x="T0_acrylic_width*(9-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*1"/>
+	<position name="T0_acrylic10_pos" x="T0_acrylic_width*(10-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*0"/>
+	<position name="T0_acrylic11_pos" x="T0_acrylic_width*(11-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*1"/>
+	<position name="T0_acrylic12_pos" x="T0_acrylic_width*(12-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*0"/>
+	<position name="T0_acrylic13_pos" x="T0_acrylic_width*(13-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*1"/>
+	<position name="T0_acrylic14_pos" x="T0_acrylic_width*(14-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*0"/>
+	<position name="T0_acrylic15_pos" x="T0_acrylic_width*(15-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*1"/>
+	<position name="T0_acrylic16_pos" x="T0_acrylic_width*(16-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*0"/>
+	<position name="T0_acrylic17_pos" x="T0_acrylic_width*(17-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*1"/>
+	<position name="T0_acrylic18_pos" x="T0_acrylic_width*(18-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*0"/>
+	<position name="T0_acrylic19_pos" x="T0_acrylic_width*(19-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*1"/>
+	    
+    <rotation name="T0_union1_rot" x="90" unit="deg"/>
+	<rotation name="T0_acrylic_rot" x="-45" unit="deg"/>
+
+	<!-- ABOVE IS FOR T0 -->
+	<!-- BELOW IS FOR TARGET -->
+	    
+	    <quantity name="target_width" value="100.0" unit="mm"/>
+	    <quantity name="target_height" value="50.0" unit="mm"/>
+	    <quantity name="target_depth" value="100" unit="mm"/>
+	    
+	    <position name="target_pos" x="0" y="0" z="380.5"/>
+
+	 <!-- ABOVE IS FOR TARGET -->
+
+  <!-- BELOW IS FOR SSD -->
+
+	<quantity name="ssdD0_thick" value=".300" unit="mm"/>
+	<quantity name="ssdD0_height" value="38.46" unit="mm"/>
+	<quantity name="ssdD0_width" value="98.33" unit="mm"/>
+	
+	<quantity name="ssdD0_chanwidth" value="0.059999" unit="mm"/>
+	<quantity name="ssdD0_changap" value="0.000001" unit="mm"/>
+	
+	<quantity name="ssdD0_overlap" value="2.0" unit="mm"/>
+	<quantity name="ssd_bkpln_thick" value=".300" unit="mm"/>
+	
+	<quantity name="ssdStation0_shift" value="0" unit="mm"/>
+	<quantity name="ssdStation1_shift" value="281" unit="mm"/>
+	<quantity name="ssdStation2_shift" value="501" unit="mm"/>
+	<quantity name="ssdStation3_shift" value="615" unit="mm"/>
+	<quantity name="ssdStation4_shift" value="846" unit="mm"/>
+	<quantity name="ssdStation5_shift" value="1146.38" unit="mm"/>
+	<quantity name="ssdStation6_shift" value="1471.82" unit="mm"/>
+	<quantity name="ssdStation7_shift" value="1744.82" unit="mm"/>
+	
+	<quantity name="mount_thick" value="6.35" unit="mm" />
+	<quantity name="mount_width" value="115.98" unit="mm" />
+	<quantity name="mount_hole" value="80.00" unit="mm" />
+	<quantity name="mount_enclosure_size" value="200" unit="mm" />
+
+	<quantity name="Mylar_Window_thick" value="0.500" unit="mm" />
+	<quantity name="Mylar_shift" value="20" unit="mm"/>
+	    
+	<quantity name="ssdStationsingleLength" value="50" unit="mm" />
+	<quantity name="ssdStationsingleWidth" value="300" unit="mm" />
+	<quantity name="ssdStationsingleHeight" value="300" unit="mm" />
+	<position name="ssdStation0_pos" x="0" y="0" z="ssdStation0_shift+ssdD0_thick-0.5*mount_thick"/>
+
+	<position name="ssdsensor_0_0_0_pos" x="0" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_0_0_0_pos" x="0" y="0" z="0*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_0_0_0_rot" x="180.0*0" y="0" z="0" unit="deg"/>
+	<position name="ssdsensor_0_1_0_pos" x="0" y="0" z="(1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_0_1_0_pos" x="0" y="0" z="1*ssdD0_thick+(1-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_0_1_0_rot" x="180.0*1" y="0" z="90" unit="deg"/>
+	<position name="ssdStation1_pos" x="0" y="0" z="ssdStation1_shift+ssdD0_thick-0.5*mount_thick"/>
+
+	<position name="ssdsensor_1_0_0_pos" x="0" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_1_0_0_pos" x="0" y="0" z="0*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_1_0_0_rot" x="180.0*0" y="0" z="0" unit="deg"/>
+	<position name="ssdsensor_1_1_0_pos" x="0" y="0" z="(1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_1_1_0_pos" x="0" y="0" z="1*ssdD0_thick+(1-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_1_1_0_rot" x="180.0*1" y="0" z="90" unit="deg"/>
+	<position name="ssdStation2_pos" x="0" y="0" z="ssdStation2_shift+ssdD0_thick-0.5*mount_thick"/>
+
+	<position name="ssdsensor_2_0_0_pos" x="0" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_2_0_0_pos" x="0" y="0" z="0*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_2_0_0_rot" x="180.0*0" y="0" z="315" unit="deg"/>
+	<position name="ssdsensor_2_1_0_pos" x="0" y="0" z="(1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_2_1_0_pos" x="0" y="0" z="1*ssdD0_thick+(1-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_2_1_0_rot" x="180.0*0" y="0" z="0" unit="deg"/>
+	<position name="ssdsensor_2_2_0_pos" x="0" y="0" z="0.5*ssdD0_thick+ssd_bkpln_thick+0.5*mount_thick+0"/>
+	<position name="ssd_bkpln_2_2_0_pos" x="0" y="0" z="0.5*ssd_bkpln_thick+0.5*mount_thick+0"/>
+	<rotation name="ssdsensor_2_2_0_rot" x="180.0*1" y="0" z="90" unit="deg"/>
+	<position name="ssdStation3_pos" x="0" y="0" z="ssdStation3_shift+ssdD0_thick-0.5*mount_thick"/>
+
+	<position name="ssdsensor_3_0_0_pos" x="0" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_3_0_0_pos" x="0" y="0" z="0*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_3_0_0_rot" x="180.0*0" y="0" z="315" unit="deg"/>
+	<position name="ssdsensor_3_1_0_pos" x="0" y="0" z="(1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_3_1_0_pos" x="0" y="0" z="1*ssdD0_thick+(1-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_3_1_0_rot" x="180.0*0" y="0" z="0" unit="deg"/>
+	<position name="ssdsensor_3_2_0_pos" x="0" y="0" z="0.5*ssdD0_thick+ssd_bkpln_thick+0.5*mount_thick+0"/>
+	<position name="ssd_bkpln_3_2_0_pos" x="0" y="0" z="0.5*ssd_bkpln_thick+0.5*mount_thick+0"/>
+	<rotation name="ssdsensor_3_2_0_rot" x="180.0*1" y="0" z="90" unit="deg"/>
+	<position name="ssdStation4_pos" x="0" y="0" z="ssdStation4_shift+ssdD0_thick-0.5*mount_thick"/>
+
+	<position name="ssdsensor_4_0_0_pos" x="0" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_4_0_0_pos" x="0" y="0" z="0*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_4_0_0_rot" x="180.0*0" y="0" z="0" unit="deg"/>
+	<position name="ssdsensor_4_1_0_pos" x="0" y="0" z="(1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_4_1_0_pos" x="0" y="0" z="1*ssdD0_thick+(1-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_4_1_0_rot" x="180.0*1" y="0" z="90" unit="deg"/>
+	<position name="ssdStation5_pos" x="0" y="0" z="ssdStation5_shift+ssdD0_thick-0.5*mount_thick"/>
+
+	<position name="ssdsensor_5_0_0_pos" x="-18.23" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_5_0_0_pos" x="-18.23" y="0" z="0*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_5_0_0_rot" x="180.0*0" y="0" z="270" unit="deg"/>
+	<position name="ssdsensor_5_0_1_pos" x="18.23" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_5_0_1_pos" x="18.23" y="0" z="0*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_5_0_1_rot" x="180.0*0" y="0" z="90" unit="deg"/>
+	<position name="ssdsensor_5_1_0_pos" x="0" y="-18.23" z="(1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_5_1_0_pos" x="0" y="-18.23" z="1*ssdD0_thick+(1-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_5_1_0_rot" x="180.0*1" y="0" z="0" unit="deg"/>
+	<position name="ssdsensor_5_1_1_pos" x="0" y="18.23" z="(1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_5_1_1_pos" x="0" y="18.23" z="1*ssdD0_thick+(1-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_5_1_1_rot" x="180.0*1" y="0" z="180" unit="deg"/>
+	<position name="ssdsensor_5_2_0_pos" x="12.92" y="-12.92" z="0.5*ssdD0_thick+ssd_bkpln_thick+0.5*mount_thick+0"/>
+	<position name="ssd_bkpln_5_2_0_pos" x="12.92" y="-12.92" z="0.5*ssd_bkpln_thick+0.5*mount_thick+0"/>
+	<rotation name="ssdsensor_5_2_0_rot" x="180.0*1" y="0" z="45" unit="deg"/>
+	<position name="ssdsensor_5_2_1_pos" x="-12.92" y="12.92" z="0.5*ssdD0_thick+ssd_bkpln_thick+0.5*mount_thick+0"/>
+	<position name="ssd_bkpln_5_2_1_pos" x="-12.92" y="12.92" z="0.5*ssd_bkpln_thick+0.5*mount_thick+0"/>
+	<rotation name="ssdsensor_5_2_1_rot" x="180.0*1" y="0" z="225" unit="deg"/>
+	<position name="ssdStation6_pos" x="0" y="0" z="ssdStation6_shift+ssdD0_thick-0.5*mount_thick"/>
+
+	<position name="ssdsensor_6_0_0_pos" x="-18.23" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_6_0_0_pos" x="-18.23" y="0" z="0*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_6_0_0_rot" x="180.0*0" y="0" z="270" unit="deg"/>
+	<position name="ssdsensor_6_0_1_pos" x="18.23" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_6_0_1_pos" x="18.23" y="0" z="0*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_6_0_1_rot" x="180.0*0" y="0" z="90" unit="deg"/>
+	<position name="ssdsensor_6_1_0_pos" x="0" y="-18.23" z="(1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_6_1_0_pos" x="0" y="-18.23" z="1*ssdD0_thick+(1-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_6_1_0_rot" x="180.0*1" y="0" z="0" unit="deg"/>
+	<position name="ssdsensor_6_1_1_pos" x="0" y="18.23" z="(1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_6_1_1_pos" x="0" y="18.23" z="1*ssdD0_thick+(1-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_6_1_1_rot" x="180.0*1" y="0" z="180" unit="deg"/>
+	<position name="ssdsensor_6_2_0_pos" x="12.92" y="-12.92" z="0.5*ssdD0_thick+ssd_bkpln_thick+0.5*mount_thick+0"/>
+	<position name="ssd_bkpln_6_2_0_pos" x="12.92" y="-12.92" z="0.5*ssd_bkpln_thick+0.5*mount_thick+0"/>
+	<rotation name="ssdsensor_6_2_0_rot" x="180.0*1" y="0" z="45" unit="deg"/>
+	<position name="ssdsensor_6_2_1_pos" x="-12.92" y="12.92" z="0.5*ssdD0_thick+ssd_bkpln_thick+0.5*mount_thick+0"/>
+	<position name="ssd_bkpln_6_2_1_pos" x="-12.92" y="12.92" z="0.5*ssd_bkpln_thick+0.5*mount_thick+0"/>
+	<rotation name="ssdsensor_6_2_1_rot" x="180.0*1" y="0" z="225" unit="deg"/>
+	<position name="ssdStation7_pos" x="0" y="0" z="ssdStation7_shift+ssdD0_thick-0.5*mount_thick"/>
+
+	<position name="ssdsensor_7_0_0_pos" x="-18.23" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_7_0_0_pos" x="-18.23" y="0" z="0*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_7_0_0_rot" x="180.0*0" y="0" z="270" unit="deg"/>
+	<position name="ssdsensor_7_0_1_pos" x="18.23" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_7_0_1_pos" x="18.23" y="0" z="0*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_7_0_1_rot" x="180.0*0" y="0" z="90" unit="deg"/>
+	<position name="ssdsensor_7_1_0_pos" x="0" y="-18.23" z="(1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_7_1_0_pos" x="0" y="-18.23" z="1*ssdD0_thick+(1-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_7_1_0_rot" x="180.0*1" y="0" z="0" unit="deg"/>
+	<position name="ssdsensor_7_1_1_pos" x="0" y="19.23" z="(1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_7_1_1_pos" x="0" y="19.23" z="1*ssdD0_thick+(1-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_7_1_1_rot" x="180.0*1" y="0" z="180" unit="deg"/>
+	<position name="ssdmount_local_0_0_pos" x="0" y="0" z="0"/>
+	<position name="ssdmount_0_0_pos" x="0" y="0" z="0+0.5*mount_thick"/>
+	<rotation name="ssdmount_0_0_rot" x="-0.44" y="-2.02" unit="deg"/>
+	<position name="ssdmount_local_1_0_pos" x="0" y="0" z="0"/>
+	<position name="ssdmount_1_0_pos" x="0" y="0" z="0+0.5*mount_thick"/>
+	<rotation name="ssdmount_1_0_rot" x="0.24" y="-1.26" unit="deg"/>
+	<position name="ssdmount_local_2_0_pos" x="0" y="0" z="0"/>
+	<position name="ssdmount_2_0_pos" x="0" y="0" z="0+0.5*mount_thick"/>
+	<rotation name="ssdmount_2_0_rot" x="0" y="0" unit="deg"/>
+	<position name="ssdmount_local_2_1_pos" x="0" y="0" z="0"/>
+	<position name="ssdmount_2_1_pos" x="0" y="0" z="10+0.5*mount_thick"/>
+	<rotation name="ssdmount_2_1_rot" x="0" y="0" unit="deg"/>
+	<position name="ssdmount_local_3_0_pos" x="0" y="0" z="0"/>
+	<position name="ssdmount_3_0_pos" x="0" y="0" z="0+0.5*mount_thick"/>
+	<rotation name="ssdmount_3_0_rot" x="0" y="0" unit="deg"/>
+	<position name="ssdmount_local_3_1_pos" x="0" y="0" z="0"/>
+	<position name="ssdmount_3_1_pos" x="0" y="0" z="10+0.5*mount_thick"/>
+	<rotation name="ssdmount_3_1_rot" x="0" y="0" unit="deg"/>
+	<position name="ssdmount_local_4_0_pos" x="0" y="0" z="0"/>
+	<position name="ssdmount_4_0_pos" x="0" y="0" z="0+0.5*mount_thick"/>
+	<rotation name="ssdmount_4_0_rot" x="0" y="0" unit="deg"/>
+	<position name="ssdmount_local_5_0_pos" x="0" y="0" z="0"/>
+	<position name="ssdmount_5_0_pos" x="0" y="0" z="0+0.5*mount_thick"/>
+	<rotation name="ssdmount_5_0_rot" x="0" y="0" unit="deg"/>
+	<position name="ssdmount_local_5_1_pos" x="0" y="0" z="0"/>
+	<position name="ssdmount_5_1_pos" x="0" y="0" z="10+0.5*mount_thick"/>
+	<rotation name="ssdmount_5_1_rot" x="0" y="0" unit="deg"/>
+	<position name="ssdmount_local_6_0_pos" x="0" y="0" z="0"/>
+	<position name="ssdmount_6_0_pos" x="0" y="0" z="0+0.5*mount_thick"/>
+	<rotation name="ssdmount_6_0_rot" x="-0.06" y="-1.49" unit="deg"/>
+	<position name="ssdmount_local_6_1_pos" x="0" y="0" z="0"/>
+	<position name="ssdmount_6_1_pos" x="0" y="0" z="10+0.5*mount_thick"/>
+	<rotation name="ssdmount_6_1_rot" x="-0.06" y="-1.49" unit="deg"/>
+	<position name="ssdmount_local_7_0_pos" x="0" y="0" z="0"/>
+	<position name="ssdmount_7_0_pos" x="0" y="0" z="0+0.5*mount_thick"/>
+	<rotation name="ssdmount_7_0_rot" x="0.36" y="0.31" unit="deg"/>
+
+	<position name="ssd_USMylarWindow_pos" x="0" y="0" z="-1*Mylar_shift"/>
+	<position name="ssd_DSMylarWindow_pos" x="0" y="0" z="Mylar_shift"/>
+
+	<position name="ssd_mount_u1_pos" x="70" y="0" z="0"/>
+	<rotation name="ssd_mount_u1_rot" y="-90" unit="deg"/>
+	<position name="ssd_mount_u2_pos" x="0" y="-70" z="0"/>
+	<rotation name="ssd_mount_u2_rot" y="-90" z="-90" unit="deg"/>
+	<rotation name="ssd_mount_u3_rot" z="90" unit="deg"/>
+	<position name="ssd_mount_u4_pos" x="80.1" y="-80.4"/>
+	<rotation name="ssd_mount_u4_rot" y="-90" z="135" unit="deg"/>
+	<position name="ssd_mount_out_pos1" z="0.5*mount_thick" unit="mm" />
+	<position name="ssd_mount_out_pos2" z="-0.5*mount_thick" unit="mm" />
+
+    <quantity name="ssdStationrotateLength" value="50" unit="mm" />
+	<quantity name="ssdStationrotateWidth" value="300" unit="mm" />
+	<quantity name="ssdStationrotateHeight" value="300" unit="mm" />
+	<quantity name="ssdStationdouble3plLength" value="100" unit="mm" />
+	<quantity name="ssdStationdouble3plWidth" value="450" unit="mm" />
+	<quantity name="ssdStationdouble3plHeight" value="450" unit="mm" />
+	<quantity name="ssdStationdouble2plLength" value="100" unit="mm" />
+	<quantity name="ssdStationdouble2plWidth" value="300" unit="mm" />
+	<quantity name="ssdStationdouble2plHeight" value="300" unit="mm" />
+
+	<position name="ssd_chan_0_pos" x="0" y="(-319.5+0)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_1_pos" x="0" y="(-319.5+1)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_2_pos" x="0" y="(-319.5+2)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_3_pos" x="0" y="(-319.5+3)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_4_pos" x="0" y="(-319.5+4)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_5_pos" x="0" y="(-319.5+5)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_6_pos" x="0" y="(-319.5+6)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_7_pos" x="0" y="(-319.5+7)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_8_pos" x="0" y="(-319.5+8)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_9_pos" x="0" y="(-319.5+9)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_10_pos" x="0" y="(-319.5+10)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_11_pos" x="0" y="(-319.5+11)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_12_pos" x="0" y="(-319.5+12)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_13_pos" x="0" y="(-319.5+13)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_14_pos" x="0" y="(-319.5+14)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_15_pos" x="0" y="(-319.5+15)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_16_pos" x="0" y="(-319.5+16)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_17_pos" x="0" y="(-319.5+17)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_18_pos" x="0" y="(-319.5+18)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_19_pos" x="0" y="(-319.5+19)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_20_pos" x="0" y="(-319.5+20)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_21_pos" x="0" y="(-319.5+21)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_22_pos" x="0" y="(-319.5+22)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_23_pos" x="0" y="(-319.5+23)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_24_pos" x="0" y="(-319.5+24)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_25_pos" x="0" y="(-319.5+25)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_26_pos" x="0" y="(-319.5+26)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_27_pos" x="0" y="(-319.5+27)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_28_pos" x="0" y="(-319.5+28)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_29_pos" x="0" y="(-319.5+29)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_30_pos" x="0" y="(-319.5+30)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_31_pos" x="0" y="(-319.5+31)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_32_pos" x="0" y="(-319.5+32)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_33_pos" x="0" y="(-319.5+33)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_34_pos" x="0" y="(-319.5+34)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_35_pos" x="0" y="(-319.5+35)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_36_pos" x="0" y="(-319.5+36)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_37_pos" x="0" y="(-319.5+37)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_38_pos" x="0" y="(-319.5+38)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_39_pos" x="0" y="(-319.5+39)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_40_pos" x="0" y="(-319.5+40)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_41_pos" x="0" y="(-319.5+41)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_42_pos" x="0" y="(-319.5+42)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_43_pos" x="0" y="(-319.5+43)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_44_pos" x="0" y="(-319.5+44)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_45_pos" x="0" y="(-319.5+45)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_46_pos" x="0" y="(-319.5+46)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_47_pos" x="0" y="(-319.5+47)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_48_pos" x="0" y="(-319.5+48)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_49_pos" x="0" y="(-319.5+49)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_50_pos" x="0" y="(-319.5+50)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_51_pos" x="0" y="(-319.5+51)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_52_pos" x="0" y="(-319.5+52)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_53_pos" x="0" y="(-319.5+53)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_54_pos" x="0" y="(-319.5+54)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_55_pos" x="0" y="(-319.5+55)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_56_pos" x="0" y="(-319.5+56)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_57_pos" x="0" y="(-319.5+57)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_58_pos" x="0" y="(-319.5+58)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_59_pos" x="0" y="(-319.5+59)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_60_pos" x="0" y="(-319.5+60)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_61_pos" x="0" y="(-319.5+61)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_62_pos" x="0" y="(-319.5+62)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_63_pos" x="0" y="(-319.5+63)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_64_pos" x="0" y="(-319.5+64)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_65_pos" x="0" y="(-319.5+65)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_66_pos" x="0" y="(-319.5+66)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_67_pos" x="0" y="(-319.5+67)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_68_pos" x="0" y="(-319.5+68)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_69_pos" x="0" y="(-319.5+69)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_70_pos" x="0" y="(-319.5+70)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_71_pos" x="0" y="(-319.5+71)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_72_pos" x="0" y="(-319.5+72)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_73_pos" x="0" y="(-319.5+73)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_74_pos" x="0" y="(-319.5+74)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_75_pos" x="0" y="(-319.5+75)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_76_pos" x="0" y="(-319.5+76)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_77_pos" x="0" y="(-319.5+77)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_78_pos" x="0" y="(-319.5+78)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_79_pos" x="0" y="(-319.5+79)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_80_pos" x="0" y="(-319.5+80)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_81_pos" x="0" y="(-319.5+81)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_82_pos" x="0" y="(-319.5+82)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_83_pos" x="0" y="(-319.5+83)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_84_pos" x="0" y="(-319.5+84)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_85_pos" x="0" y="(-319.5+85)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_86_pos" x="0" y="(-319.5+86)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_87_pos" x="0" y="(-319.5+87)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_88_pos" x="0" y="(-319.5+88)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_89_pos" x="0" y="(-319.5+89)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_90_pos" x="0" y="(-319.5+90)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_91_pos" x="0" y="(-319.5+91)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_92_pos" x="0" y="(-319.5+92)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_93_pos" x="0" y="(-319.5+93)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_94_pos" x="0" y="(-319.5+94)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_95_pos" x="0" y="(-319.5+95)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_96_pos" x="0" y="(-319.5+96)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_97_pos" x="0" y="(-319.5+97)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_98_pos" x="0" y="(-319.5+98)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_99_pos" x="0" y="(-319.5+99)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_100_pos" x="0" y="(-319.5+100)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_101_pos" x="0" y="(-319.5+101)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_102_pos" x="0" y="(-319.5+102)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_103_pos" x="0" y="(-319.5+103)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_104_pos" x="0" y="(-319.5+104)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_105_pos" x="0" y="(-319.5+105)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_106_pos" x="0" y="(-319.5+106)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_107_pos" x="0" y="(-319.5+107)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_108_pos" x="0" y="(-319.5+108)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_109_pos" x="0" y="(-319.5+109)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_110_pos" x="0" y="(-319.5+110)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_111_pos" x="0" y="(-319.5+111)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_112_pos" x="0" y="(-319.5+112)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_113_pos" x="0" y="(-319.5+113)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_114_pos" x="0" y="(-319.5+114)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_115_pos" x="0" y="(-319.5+115)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_116_pos" x="0" y="(-319.5+116)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_117_pos" x="0" y="(-319.5+117)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_118_pos" x="0" y="(-319.5+118)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_119_pos" x="0" y="(-319.5+119)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_120_pos" x="0" y="(-319.5+120)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_121_pos" x="0" y="(-319.5+121)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_122_pos" x="0" y="(-319.5+122)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_123_pos" x="0" y="(-319.5+123)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_124_pos" x="0" y="(-319.5+124)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_125_pos" x="0" y="(-319.5+125)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_126_pos" x="0" y="(-319.5+126)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_127_pos" x="0" y="(-319.5+127)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_128_pos" x="0" y="(-319.5+128)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_129_pos" x="0" y="(-319.5+129)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_130_pos" x="0" y="(-319.5+130)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_131_pos" x="0" y="(-319.5+131)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_132_pos" x="0" y="(-319.5+132)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_133_pos" x="0" y="(-319.5+133)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_134_pos" x="0" y="(-319.5+134)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_135_pos" x="0" y="(-319.5+135)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_136_pos" x="0" y="(-319.5+136)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_137_pos" x="0" y="(-319.5+137)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_138_pos" x="0" y="(-319.5+138)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_139_pos" x="0" y="(-319.5+139)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_140_pos" x="0" y="(-319.5+140)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_141_pos" x="0" y="(-319.5+141)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_142_pos" x="0" y="(-319.5+142)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_143_pos" x="0" y="(-319.5+143)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_144_pos" x="0" y="(-319.5+144)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_145_pos" x="0" y="(-319.5+145)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_146_pos" x="0" y="(-319.5+146)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_147_pos" x="0" y="(-319.5+147)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_148_pos" x="0" y="(-319.5+148)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_149_pos" x="0" y="(-319.5+149)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_150_pos" x="0" y="(-319.5+150)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_151_pos" x="0" y="(-319.5+151)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_152_pos" x="0" y="(-319.5+152)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_153_pos" x="0" y="(-319.5+153)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_154_pos" x="0" y="(-319.5+154)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_155_pos" x="0" y="(-319.5+155)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_156_pos" x="0" y="(-319.5+156)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_157_pos" x="0" y="(-319.5+157)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_158_pos" x="0" y="(-319.5+158)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_159_pos" x="0" y="(-319.5+159)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_160_pos" x="0" y="(-319.5+160)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_161_pos" x="0" y="(-319.5+161)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_162_pos" x="0" y="(-319.5+162)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_163_pos" x="0" y="(-319.5+163)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_164_pos" x="0" y="(-319.5+164)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_165_pos" x="0" y="(-319.5+165)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_166_pos" x="0" y="(-319.5+166)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_167_pos" x="0" y="(-319.5+167)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_168_pos" x="0" y="(-319.5+168)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_169_pos" x="0" y="(-319.5+169)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_170_pos" x="0" y="(-319.5+170)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_171_pos" x="0" y="(-319.5+171)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_172_pos" x="0" y="(-319.5+172)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_173_pos" x="0" y="(-319.5+173)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_174_pos" x="0" y="(-319.5+174)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_175_pos" x="0" y="(-319.5+175)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_176_pos" x="0" y="(-319.5+176)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_177_pos" x="0" y="(-319.5+177)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_178_pos" x="0" y="(-319.5+178)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_179_pos" x="0" y="(-319.5+179)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_180_pos" x="0" y="(-319.5+180)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_181_pos" x="0" y="(-319.5+181)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_182_pos" x="0" y="(-319.5+182)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_183_pos" x="0" y="(-319.5+183)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_184_pos" x="0" y="(-319.5+184)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_185_pos" x="0" y="(-319.5+185)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_186_pos" x="0" y="(-319.5+186)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_187_pos" x="0" y="(-319.5+187)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_188_pos" x="0" y="(-319.5+188)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_189_pos" x="0" y="(-319.5+189)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_190_pos" x="0" y="(-319.5+190)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_191_pos" x="0" y="(-319.5+191)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_192_pos" x="0" y="(-319.5+192)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_193_pos" x="0" y="(-319.5+193)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_194_pos" x="0" y="(-319.5+194)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_195_pos" x="0" y="(-319.5+195)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_196_pos" x="0" y="(-319.5+196)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_197_pos" x="0" y="(-319.5+197)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_198_pos" x="0" y="(-319.5+198)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_199_pos" x="0" y="(-319.5+199)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_200_pos" x="0" y="(-319.5+200)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_201_pos" x="0" y="(-319.5+201)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_202_pos" x="0" y="(-319.5+202)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_203_pos" x="0" y="(-319.5+203)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_204_pos" x="0" y="(-319.5+204)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_205_pos" x="0" y="(-319.5+205)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_206_pos" x="0" y="(-319.5+206)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_207_pos" x="0" y="(-319.5+207)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_208_pos" x="0" y="(-319.5+208)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_209_pos" x="0" y="(-319.5+209)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_210_pos" x="0" y="(-319.5+210)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_211_pos" x="0" y="(-319.5+211)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_212_pos" x="0" y="(-319.5+212)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_213_pos" x="0" y="(-319.5+213)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_214_pos" x="0" y="(-319.5+214)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_215_pos" x="0" y="(-319.5+215)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_216_pos" x="0" y="(-319.5+216)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_217_pos" x="0" y="(-319.5+217)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_218_pos" x="0" y="(-319.5+218)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_219_pos" x="0" y="(-319.5+219)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_220_pos" x="0" y="(-319.5+220)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_221_pos" x="0" y="(-319.5+221)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_222_pos" x="0" y="(-319.5+222)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_223_pos" x="0" y="(-319.5+223)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_224_pos" x="0" y="(-319.5+224)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_225_pos" x="0" y="(-319.5+225)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_226_pos" x="0" y="(-319.5+226)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_227_pos" x="0" y="(-319.5+227)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_228_pos" x="0" y="(-319.5+228)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_229_pos" x="0" y="(-319.5+229)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_230_pos" x="0" y="(-319.5+230)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_231_pos" x="0" y="(-319.5+231)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_232_pos" x="0" y="(-319.5+232)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_233_pos" x="0" y="(-319.5+233)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_234_pos" x="0" y="(-319.5+234)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_235_pos" x="0" y="(-319.5+235)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_236_pos" x="0" y="(-319.5+236)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_237_pos" x="0" y="(-319.5+237)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_238_pos" x="0" y="(-319.5+238)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_239_pos" x="0" y="(-319.5+239)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_240_pos" x="0" y="(-319.5+240)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_241_pos" x="0" y="(-319.5+241)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_242_pos" x="0" y="(-319.5+242)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_243_pos" x="0" y="(-319.5+243)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_244_pos" x="0" y="(-319.5+244)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_245_pos" x="0" y="(-319.5+245)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_246_pos" x="0" y="(-319.5+246)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_247_pos" x="0" y="(-319.5+247)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_248_pos" x="0" y="(-319.5+248)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_249_pos" x="0" y="(-319.5+249)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_250_pos" x="0" y="(-319.5+250)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_251_pos" x="0" y="(-319.5+251)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_252_pos" x="0" y="(-319.5+252)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_253_pos" x="0" y="(-319.5+253)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_254_pos" x="0" y="(-319.5+254)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_255_pos" x="0" y="(-319.5+255)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_256_pos" x="0" y="(-319.5+256)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_257_pos" x="0" y="(-319.5+257)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_258_pos" x="0" y="(-319.5+258)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_259_pos" x="0" y="(-319.5+259)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_260_pos" x="0" y="(-319.5+260)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_261_pos" x="0" y="(-319.5+261)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_262_pos" x="0" y="(-319.5+262)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_263_pos" x="0" y="(-319.5+263)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_264_pos" x="0" y="(-319.5+264)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_265_pos" x="0" y="(-319.5+265)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_266_pos" x="0" y="(-319.5+266)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_267_pos" x="0" y="(-319.5+267)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_268_pos" x="0" y="(-319.5+268)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_269_pos" x="0" y="(-319.5+269)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_270_pos" x="0" y="(-319.5+270)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_271_pos" x="0" y="(-319.5+271)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_272_pos" x="0" y="(-319.5+272)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_273_pos" x="0" y="(-319.5+273)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_274_pos" x="0" y="(-319.5+274)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_275_pos" x="0" y="(-319.5+275)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_276_pos" x="0" y="(-319.5+276)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_277_pos" x="0" y="(-319.5+277)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_278_pos" x="0" y="(-319.5+278)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_279_pos" x="0" y="(-319.5+279)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_280_pos" x="0" y="(-319.5+280)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_281_pos" x="0" y="(-319.5+281)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_282_pos" x="0" y="(-319.5+282)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_283_pos" x="0" y="(-319.5+283)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_284_pos" x="0" y="(-319.5+284)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_285_pos" x="0" y="(-319.5+285)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_286_pos" x="0" y="(-319.5+286)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_287_pos" x="0" y="(-319.5+287)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_288_pos" x="0" y="(-319.5+288)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_289_pos" x="0" y="(-319.5+289)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_290_pos" x="0" y="(-319.5+290)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_291_pos" x="0" y="(-319.5+291)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_292_pos" x="0" y="(-319.5+292)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_293_pos" x="0" y="(-319.5+293)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_294_pos" x="0" y="(-319.5+294)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_295_pos" x="0" y="(-319.5+295)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_296_pos" x="0" y="(-319.5+296)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_297_pos" x="0" y="(-319.5+297)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_298_pos" x="0" y="(-319.5+298)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_299_pos" x="0" y="(-319.5+299)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_300_pos" x="0" y="(-319.5+300)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_301_pos" x="0" y="(-319.5+301)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_302_pos" x="0" y="(-319.5+302)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_303_pos" x="0" y="(-319.5+303)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_304_pos" x="0" y="(-319.5+304)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_305_pos" x="0" y="(-319.5+305)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_306_pos" x="0" y="(-319.5+306)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_307_pos" x="0" y="(-319.5+307)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_308_pos" x="0" y="(-319.5+308)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_309_pos" x="0" y="(-319.5+309)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_310_pos" x="0" y="(-319.5+310)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_311_pos" x="0" y="(-319.5+311)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_312_pos" x="0" y="(-319.5+312)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_313_pos" x="0" y="(-319.5+313)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_314_pos" x="0" y="(-319.5+314)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_315_pos" x="0" y="(-319.5+315)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_316_pos" x="0" y="(-319.5+316)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_317_pos" x="0" y="(-319.5+317)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_318_pos" x="0" y="(-319.5+318)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_319_pos" x="0" y="(-319.5+319)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_320_pos" x="0" y="(-319.5+320)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_321_pos" x="0" y="(-319.5+321)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_322_pos" x="0" y="(-319.5+322)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_323_pos" x="0" y="(-319.5+323)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_324_pos" x="0" y="(-319.5+324)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_325_pos" x="0" y="(-319.5+325)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_326_pos" x="0" y="(-319.5+326)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_327_pos" x="0" y="(-319.5+327)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_328_pos" x="0" y="(-319.5+328)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_329_pos" x="0" y="(-319.5+329)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_330_pos" x="0" y="(-319.5+330)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_331_pos" x="0" y="(-319.5+331)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_332_pos" x="0" y="(-319.5+332)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_333_pos" x="0" y="(-319.5+333)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_334_pos" x="0" y="(-319.5+334)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_335_pos" x="0" y="(-319.5+335)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_336_pos" x="0" y="(-319.5+336)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_337_pos" x="0" y="(-319.5+337)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_338_pos" x="0" y="(-319.5+338)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_339_pos" x="0" y="(-319.5+339)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_340_pos" x="0" y="(-319.5+340)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_341_pos" x="0" y="(-319.5+341)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_342_pos" x="0" y="(-319.5+342)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_343_pos" x="0" y="(-319.5+343)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_344_pos" x="0" y="(-319.5+344)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_345_pos" x="0" y="(-319.5+345)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_346_pos" x="0" y="(-319.5+346)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_347_pos" x="0" y="(-319.5+347)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_348_pos" x="0" y="(-319.5+348)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_349_pos" x="0" y="(-319.5+349)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_350_pos" x="0" y="(-319.5+350)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_351_pos" x="0" y="(-319.5+351)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_352_pos" x="0" y="(-319.5+352)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_353_pos" x="0" y="(-319.5+353)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_354_pos" x="0" y="(-319.5+354)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_355_pos" x="0" y="(-319.5+355)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_356_pos" x="0" y="(-319.5+356)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_357_pos" x="0" y="(-319.5+357)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_358_pos" x="0" y="(-319.5+358)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_359_pos" x="0" y="(-319.5+359)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_360_pos" x="0" y="(-319.5+360)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_361_pos" x="0" y="(-319.5+361)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_362_pos" x="0" y="(-319.5+362)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_363_pos" x="0" y="(-319.5+363)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_364_pos" x="0" y="(-319.5+364)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_365_pos" x="0" y="(-319.5+365)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_366_pos" x="0" y="(-319.5+366)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_367_pos" x="0" y="(-319.5+367)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_368_pos" x="0" y="(-319.5+368)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_369_pos" x="0" y="(-319.5+369)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_370_pos" x="0" y="(-319.5+370)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_371_pos" x="0" y="(-319.5+371)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_372_pos" x="0" y="(-319.5+372)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_373_pos" x="0" y="(-319.5+373)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_374_pos" x="0" y="(-319.5+374)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_375_pos" x="0" y="(-319.5+375)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_376_pos" x="0" y="(-319.5+376)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_377_pos" x="0" y="(-319.5+377)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_378_pos" x="0" y="(-319.5+378)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_379_pos" x="0" y="(-319.5+379)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_380_pos" x="0" y="(-319.5+380)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_381_pos" x="0" y="(-319.5+381)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_382_pos" x="0" y="(-319.5+382)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_383_pos" x="0" y="(-319.5+383)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_384_pos" x="0" y="(-319.5+384)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_385_pos" x="0" y="(-319.5+385)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_386_pos" x="0" y="(-319.5+386)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_387_pos" x="0" y="(-319.5+387)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_388_pos" x="0" y="(-319.5+388)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_389_pos" x="0" y="(-319.5+389)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_390_pos" x="0" y="(-319.5+390)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_391_pos" x="0" y="(-319.5+391)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_392_pos" x="0" y="(-319.5+392)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_393_pos" x="0" y="(-319.5+393)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_394_pos" x="0" y="(-319.5+394)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_395_pos" x="0" y="(-319.5+395)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_396_pos" x="0" y="(-319.5+396)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_397_pos" x="0" y="(-319.5+397)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_398_pos" x="0" y="(-319.5+398)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_399_pos" x="0" y="(-319.5+399)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_400_pos" x="0" y="(-319.5+400)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_401_pos" x="0" y="(-319.5+401)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_402_pos" x="0" y="(-319.5+402)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_403_pos" x="0" y="(-319.5+403)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_404_pos" x="0" y="(-319.5+404)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_405_pos" x="0" y="(-319.5+405)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_406_pos" x="0" y="(-319.5+406)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_407_pos" x="0" y="(-319.5+407)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_408_pos" x="0" y="(-319.5+408)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_409_pos" x="0" y="(-319.5+409)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_410_pos" x="0" y="(-319.5+410)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_411_pos" x="0" y="(-319.5+411)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_412_pos" x="0" y="(-319.5+412)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_413_pos" x="0" y="(-319.5+413)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_414_pos" x="0" y="(-319.5+414)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_415_pos" x="0" y="(-319.5+415)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_416_pos" x="0" y="(-319.5+416)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_417_pos" x="0" y="(-319.5+417)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_418_pos" x="0" y="(-319.5+418)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_419_pos" x="0" y="(-319.5+419)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_420_pos" x="0" y="(-319.5+420)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_421_pos" x="0" y="(-319.5+421)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_422_pos" x="0" y="(-319.5+422)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_423_pos" x="0" y="(-319.5+423)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_424_pos" x="0" y="(-319.5+424)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_425_pos" x="0" y="(-319.5+425)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_426_pos" x="0" y="(-319.5+426)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_427_pos" x="0" y="(-319.5+427)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_428_pos" x="0" y="(-319.5+428)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_429_pos" x="0" y="(-319.5+429)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_430_pos" x="0" y="(-319.5+430)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_431_pos" x="0" y="(-319.5+431)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_432_pos" x="0" y="(-319.5+432)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_433_pos" x="0" y="(-319.5+433)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_434_pos" x="0" y="(-319.5+434)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_435_pos" x="0" y="(-319.5+435)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_436_pos" x="0" y="(-319.5+436)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_437_pos" x="0" y="(-319.5+437)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_438_pos" x="0" y="(-319.5+438)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_439_pos" x="0" y="(-319.5+439)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_440_pos" x="0" y="(-319.5+440)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_441_pos" x="0" y="(-319.5+441)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_442_pos" x="0" y="(-319.5+442)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_443_pos" x="0" y="(-319.5+443)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_444_pos" x="0" y="(-319.5+444)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_445_pos" x="0" y="(-319.5+445)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_446_pos" x="0" y="(-319.5+446)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_447_pos" x="0" y="(-319.5+447)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_448_pos" x="0" y="(-319.5+448)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_449_pos" x="0" y="(-319.5+449)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_450_pos" x="0" y="(-319.5+450)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_451_pos" x="0" y="(-319.5+451)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_452_pos" x="0" y="(-319.5+452)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_453_pos" x="0" y="(-319.5+453)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_454_pos" x="0" y="(-319.5+454)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_455_pos" x="0" y="(-319.5+455)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_456_pos" x="0" y="(-319.5+456)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_457_pos" x="0" y="(-319.5+457)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_458_pos" x="0" y="(-319.5+458)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_459_pos" x="0" y="(-319.5+459)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_460_pos" x="0" y="(-319.5+460)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_461_pos" x="0" y="(-319.5+461)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_462_pos" x="0" y="(-319.5+462)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_463_pos" x="0" y="(-319.5+463)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_464_pos" x="0" y="(-319.5+464)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_465_pos" x="0" y="(-319.5+465)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_466_pos" x="0" y="(-319.5+466)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_467_pos" x="0" y="(-319.5+467)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_468_pos" x="0" y="(-319.5+468)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_469_pos" x="0" y="(-319.5+469)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_470_pos" x="0" y="(-319.5+470)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_471_pos" x="0" y="(-319.5+471)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_472_pos" x="0" y="(-319.5+472)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_473_pos" x="0" y="(-319.5+473)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_474_pos" x="0" y="(-319.5+474)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_475_pos" x="0" y="(-319.5+475)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_476_pos" x="0" y="(-319.5+476)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_477_pos" x="0" y="(-319.5+477)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_478_pos" x="0" y="(-319.5+478)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_479_pos" x="0" y="(-319.5+479)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_480_pos" x="0" y="(-319.5+480)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_481_pos" x="0" y="(-319.5+481)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_482_pos" x="0" y="(-319.5+482)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_483_pos" x="0" y="(-319.5+483)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_484_pos" x="0" y="(-319.5+484)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_485_pos" x="0" y="(-319.5+485)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_486_pos" x="0" y="(-319.5+486)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_487_pos" x="0" y="(-319.5+487)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_488_pos" x="0" y="(-319.5+488)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_489_pos" x="0" y="(-319.5+489)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_490_pos" x="0" y="(-319.5+490)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_491_pos" x="0" y="(-319.5+491)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_492_pos" x="0" y="(-319.5+492)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_493_pos" x="0" y="(-319.5+493)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_494_pos" x="0" y="(-319.5+494)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_495_pos" x="0" y="(-319.5+495)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_496_pos" x="0" y="(-319.5+496)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_497_pos" x="0" y="(-319.5+497)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_498_pos" x="0" y="(-319.5+498)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_499_pos" x="0" y="(-319.5+499)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_500_pos" x="0" y="(-319.5+500)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_501_pos" x="0" y="(-319.5+501)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_502_pos" x="0" y="(-319.5+502)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_503_pos" x="0" y="(-319.5+503)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_504_pos" x="0" y="(-319.5+504)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_505_pos" x="0" y="(-319.5+505)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_506_pos" x="0" y="(-319.5+506)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_507_pos" x="0" y="(-319.5+507)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_508_pos" x="0" y="(-319.5+508)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_509_pos" x="0" y="(-319.5+509)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_510_pos" x="0" y="(-319.5+510)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_511_pos" x="0" y="(-319.5+511)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_512_pos" x="0" y="(-319.5+512)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_513_pos" x="0" y="(-319.5+513)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_514_pos" x="0" y="(-319.5+514)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_515_pos" x="0" y="(-319.5+515)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_516_pos" x="0" y="(-319.5+516)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_517_pos" x="0" y="(-319.5+517)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_518_pos" x="0" y="(-319.5+518)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_519_pos" x="0" y="(-319.5+519)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_520_pos" x="0" y="(-319.5+520)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_521_pos" x="0" y="(-319.5+521)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_522_pos" x="0" y="(-319.5+522)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_523_pos" x="0" y="(-319.5+523)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_524_pos" x="0" y="(-319.5+524)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_525_pos" x="0" y="(-319.5+525)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_526_pos" x="0" y="(-319.5+526)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_527_pos" x="0" y="(-319.5+527)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_528_pos" x="0" y="(-319.5+528)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_529_pos" x="0" y="(-319.5+529)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_530_pos" x="0" y="(-319.5+530)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_531_pos" x="0" y="(-319.5+531)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_532_pos" x="0" y="(-319.5+532)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_533_pos" x="0" y="(-319.5+533)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_534_pos" x="0" y="(-319.5+534)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_535_pos" x="0" y="(-319.5+535)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_536_pos" x="0" y="(-319.5+536)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_537_pos" x="0" y="(-319.5+537)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_538_pos" x="0" y="(-319.5+538)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_539_pos" x="0" y="(-319.5+539)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_540_pos" x="0" y="(-319.5+540)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_541_pos" x="0" y="(-319.5+541)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_542_pos" x="0" y="(-319.5+542)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_543_pos" x="0" y="(-319.5+543)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_544_pos" x="0" y="(-319.5+544)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_545_pos" x="0" y="(-319.5+545)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_546_pos" x="0" y="(-319.5+546)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_547_pos" x="0" y="(-319.5+547)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_548_pos" x="0" y="(-319.5+548)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_549_pos" x="0" y="(-319.5+549)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_550_pos" x="0" y="(-319.5+550)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_551_pos" x="0" y="(-319.5+551)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_552_pos" x="0" y="(-319.5+552)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_553_pos" x="0" y="(-319.5+553)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_554_pos" x="0" y="(-319.5+554)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_555_pos" x="0" y="(-319.5+555)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_556_pos" x="0" y="(-319.5+556)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_557_pos" x="0" y="(-319.5+557)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_558_pos" x="0" y="(-319.5+558)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_559_pos" x="0" y="(-319.5+559)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_560_pos" x="0" y="(-319.5+560)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_561_pos" x="0" y="(-319.5+561)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_562_pos" x="0" y="(-319.5+562)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_563_pos" x="0" y="(-319.5+563)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_564_pos" x="0" y="(-319.5+564)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_565_pos" x="0" y="(-319.5+565)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_566_pos" x="0" y="(-319.5+566)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_567_pos" x="0" y="(-319.5+567)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_568_pos" x="0" y="(-319.5+568)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_569_pos" x="0" y="(-319.5+569)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_570_pos" x="0" y="(-319.5+570)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_571_pos" x="0" y="(-319.5+571)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_572_pos" x="0" y="(-319.5+572)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_573_pos" x="0" y="(-319.5+573)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_574_pos" x="0" y="(-319.5+574)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_575_pos" x="0" y="(-319.5+575)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_576_pos" x="0" y="(-319.5+576)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_577_pos" x="0" y="(-319.5+577)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_578_pos" x="0" y="(-319.5+578)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_579_pos" x="0" y="(-319.5+579)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_580_pos" x="0" y="(-319.5+580)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_581_pos" x="0" y="(-319.5+581)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_582_pos" x="0" y="(-319.5+582)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_583_pos" x="0" y="(-319.5+583)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_584_pos" x="0" y="(-319.5+584)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_585_pos" x="0" y="(-319.5+585)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_586_pos" x="0" y="(-319.5+586)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_587_pos" x="0" y="(-319.5+587)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_588_pos" x="0" y="(-319.5+588)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_589_pos" x="0" y="(-319.5+589)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_590_pos" x="0" y="(-319.5+590)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_591_pos" x="0" y="(-319.5+591)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_592_pos" x="0" y="(-319.5+592)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_593_pos" x="0" y="(-319.5+593)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_594_pos" x="0" y="(-319.5+594)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_595_pos" x="0" y="(-319.5+595)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_596_pos" x="0" y="(-319.5+596)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_597_pos" x="0" y="(-319.5+597)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_598_pos" x="0" y="(-319.5+598)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_599_pos" x="0" y="(-319.5+599)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_600_pos" x="0" y="(-319.5+600)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_601_pos" x="0" y="(-319.5+601)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_602_pos" x="0" y="(-319.5+602)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_603_pos" x="0" y="(-319.5+603)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_604_pos" x="0" y="(-319.5+604)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_605_pos" x="0" y="(-319.5+605)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_606_pos" x="0" y="(-319.5+606)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_607_pos" x="0" y="(-319.5+607)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_608_pos" x="0" y="(-319.5+608)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_609_pos" x="0" y="(-319.5+609)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_610_pos" x="0" y="(-319.5+610)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_611_pos" x="0" y="(-319.5+611)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_612_pos" x="0" y="(-319.5+612)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_613_pos" x="0" y="(-319.5+613)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_614_pos" x="0" y="(-319.5+614)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_615_pos" x="0" y="(-319.5+615)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_616_pos" x="0" y="(-319.5+616)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_617_pos" x="0" y="(-319.5+617)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_618_pos" x="0" y="(-319.5+618)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_619_pos" x="0" y="(-319.5+619)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_620_pos" x="0" y="(-319.5+620)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_621_pos" x="0" y="(-319.5+621)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_622_pos" x="0" y="(-319.5+622)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_623_pos" x="0" y="(-319.5+623)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_624_pos" x="0" y="(-319.5+624)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_625_pos" x="0" y="(-319.5+625)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_626_pos" x="0" y="(-319.5+626)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_627_pos" x="0" y="(-319.5+627)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_628_pos" x="0" y="(-319.5+628)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_629_pos" x="0" y="(-319.5+629)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_630_pos" x="0" y="(-319.5+630)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_631_pos" x="0" y="(-319.5+631)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_632_pos" x="0" y="(-319.5+632)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_633_pos" x="0" y="(-319.5+633)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_634_pos" x="0" y="(-319.5+634)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_635_pos" x="0" y="(-319.5+635)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_636_pos" x="0" y="(-319.5+636)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_637_pos" x="0" y="(-319.5+637)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_638_pos" x="0" y="(-319.5+638)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_639_pos" x="0" y="(-319.5+639)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<!-- ABOVE IS FOR SSD -->
+	<!-- BELOW IS FOR ARICH -->
+
+	<quantity name="arich_shift" value="1862.82" unit="mm"/>
+	<quantity name="arich_thick" value="280.0" unit="mm"/>
+	<quantity name="arich_width" value="365.0" unit="mm"/>
+	<quantity name="arich_height" value="365.0" unit="mm"/>
+
+	<position name="arich_pos" x="0" y="0" z="arich_shift+0.5*arich_thick" />
+	<quantity name="aerogel_thick0" value="18.9" unit="mm"/>
+	<quantity name="aerogel_thick1" value="20.4" unit="mm"/>
+	<quantity name="aerogel_size" value="93.0" unit="mm"/>
+	<quantity name="aerogel_shift" value="43.0" unit="mm"/>
+	 
+	<position name="aerogel_pos0" x="0" y="0" z="aerogel_shift-0.5*arich_thick+0.5*aerogel_thick0" />
+	<position name="aerogel_pos1" x="0" y="0" z="aerogel_shift-0.5*arich_thick+aerogel_thick0+0.5*aerogel_thick1" />
+
+	<quantity name="mPMT_thick" value="16.4" unit="mm"/>
+	<quantity name="mPMT_size" value="49.3" unit="mm"/>
+	<quantity name="mPMT_gap" value="5.4" unit="mm"/>
+	<quantity name="manode_size" value="6.0" unit="mm"/>
+	<quantity name="mPMT_shift" value="103.0" unit="mm"/>
+
+	<position name="mPMT0_0_anode0_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode0_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode0_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode0_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode0_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode0_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode0_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode0_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode1_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode1_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode1_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode1_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode1_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode1_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode1_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode1_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode2_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode2_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode2_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode2_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode2_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode2_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode2_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode2_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode3_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode3_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode3_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode3_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode3_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode3_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode3_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode3_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode4_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode4_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode4_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode4_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode4_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode4_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode4_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode4_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode5_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode5_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode5_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode5_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode5_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode5_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode5_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode5_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode6_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode6_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode6_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode6_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode6_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode6_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode6_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode6_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode7_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode7_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode7_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode7_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode7_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode7_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode7_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode7_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode0_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode0_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode0_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode0_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode0_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode0_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode0_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode0_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode1_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode1_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode1_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode1_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode1_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode1_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode1_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode1_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode2_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode2_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode2_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode2_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode2_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode2_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode2_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode2_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode3_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode3_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode3_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode3_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode3_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode3_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode3_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode3_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode4_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode4_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode4_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode4_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode4_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode4_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode4_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode4_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode5_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode5_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode5_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode5_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode5_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode5_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode5_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode5_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode6_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode6_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode6_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode6_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode6_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode6_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode6_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode6_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode7_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode7_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode7_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode7_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode7_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode7_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode7_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode7_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode0_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode0_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode0_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode0_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode0_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode0_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode0_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode0_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode1_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode1_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode1_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode1_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode1_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode1_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode1_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode1_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode2_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode2_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode2_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode2_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode2_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode2_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode2_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode2_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode3_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode3_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode3_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode3_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode3_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode3_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode3_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode3_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode4_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode4_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode4_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode4_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode4_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode4_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode4_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode4_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode5_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode5_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode5_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode5_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode5_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode5_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode5_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode5_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode6_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode6_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode6_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode6_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode6_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode6_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode6_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode6_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode7_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode7_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode7_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode7_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode7_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode7_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode7_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode7_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode0_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode0_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode0_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode0_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode0_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode0_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode0_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode0_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode1_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode1_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode1_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode1_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode1_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode1_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode1_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode1_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode2_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode2_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode2_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode2_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode2_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode2_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode2_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode2_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode3_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode3_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode3_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode3_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode3_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode3_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode3_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode3_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode4_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode4_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode4_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode4_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode4_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode4_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode4_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode4_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode5_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode5_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode5_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode5_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode5_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode5_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode5_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode5_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode6_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode6_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode6_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode6_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode6_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode6_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode6_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode6_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode7_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode7_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode7_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode7_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode7_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode7_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode7_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode7_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode0_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode0_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode0_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode0_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode0_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode0_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode0_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode0_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode1_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode1_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode1_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode1_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode1_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode1_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode1_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode1_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode2_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode2_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode2_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode2_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode2_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode2_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode2_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode2_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode3_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode3_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode3_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode3_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode3_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode3_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode3_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode3_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode4_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode4_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode4_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode4_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode4_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode4_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode4_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode4_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode5_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode5_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode5_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode5_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode5_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode5_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode5_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode5_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode6_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode6_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode6_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode6_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode6_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode6_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode6_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode6_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode7_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode7_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode7_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode7_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode7_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode7_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode7_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode7_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode0_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode0_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode0_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode0_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode0_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode0_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode0_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode0_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode1_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode1_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode1_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode1_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode1_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode1_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode1_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode1_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode2_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode2_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode2_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode2_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode2_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode2_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode2_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode2_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode3_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode3_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode3_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode3_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode3_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode3_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode3_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode3_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode4_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode4_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode4_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode4_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode4_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode4_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode4_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode4_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode5_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode5_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode5_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode5_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode5_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode5_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode5_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode5_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode6_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode6_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode6_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode6_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode6_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode6_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode6_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode6_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode7_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode7_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode7_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode7_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode7_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode7_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode7_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode7_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode0_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode0_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode0_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode0_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode0_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode0_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode0_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode0_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode1_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode1_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode1_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode1_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode1_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode1_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode1_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode1_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode2_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode2_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode2_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode2_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode2_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode2_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode2_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode2_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode3_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode3_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode3_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode3_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode3_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode3_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode3_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode3_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode4_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode4_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode4_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode4_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode4_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode4_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode4_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode4_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode5_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode5_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode5_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode5_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode5_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode5_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode5_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode5_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode6_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode6_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode6_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode6_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode6_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode6_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode6_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode6_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode7_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode7_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode7_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode7_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode7_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode7_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode7_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode7_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode0_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode0_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode0_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode0_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode0_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode0_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode0_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode0_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode1_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode1_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode1_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode1_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode1_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode1_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode1_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode1_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode2_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode2_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode2_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode2_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode2_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode2_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode2_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode2_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode3_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode3_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode3_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode3_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode3_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode3_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode3_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode3_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode4_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode4_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode4_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode4_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode4_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode4_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode4_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode4_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode5_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode5_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode5_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode5_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode5_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode5_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode5_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode5_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode6_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode6_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode6_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode6_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode6_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode6_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode6_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode6_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode7_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode7_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode7_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode7_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode7_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode7_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode7_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode7_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode0_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode0_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode0_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode0_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode0_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode0_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode0_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode0_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode1_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode1_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode1_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode1_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode1_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode1_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode1_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode1_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode2_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode2_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode2_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode2_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode2_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode2_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode2_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode2_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode3_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode3_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode3_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode3_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode3_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode3_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode3_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode3_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode4_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode4_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode4_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode4_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode4_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode4_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode4_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode4_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode5_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode5_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode5_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode5_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode5_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode5_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode5_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode5_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode6_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode6_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode6_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode6_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode6_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode6_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode6_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode6_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode7_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode7_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode7_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode7_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode7_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode7_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode7_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode7_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+ 
+	<quantity name="PMTplate_thick" value="5.8" unit="mm"/>
+	<quantity name="PMTplate_size" value="195.7" unit="mm"/>
+
+	<position name="PMTplate_pos" x="0" y="0" z="mPMT_shift+mPMT_thick+0.5*PMTplate_thick" />
+	<!-- ABOVE IS FOR ARICH -->
+
+	 <!-- BELOW IS FOR RPC -->
+
+	 <quantity name="RPC_thick" value="54" unit="mm" />
+	 <quantity name="RPC_width" value="1066" unit="mm" />
+	 <quantity name="RPC_height" value="252" unit="mm" />
+	 <quantity name="RPC_volume_thick" value="200" unit="mm" />
+	 <quantity name="RPC0_shift" value="3953.38" unit="mm" />
+	 <quantity name="RPC1_shift" value="4050.39" unit="mm" />
+	 <quantity name="RPC_shift" value="4028.89" unit="mm" />
+
+	 <quantity name="RPC_Al_thick" value="1" unit="mm" />
+	 <quantity name="RPC_comb_thick" value="17" unit="mm" />
+	 <quantity name="RPC_PCB_thick" value="1" unit="mm" />
+	 <quantity name="RPC_acrylic_thick" value="1" unit="mm" />
+	 <quantity name="RPC_gas_width" value="960.5" unit="mm" />
+	 <quantity name="RPC_gas_height" value="250.5" unit="mm" />
+	 <quantity name="RPC_gas_thick" value="6" unit="mm" />
+
+	 <position name="RPC_pos" z="RPC_shift" unit="mm" />
+     <position name="RPC0_pos" z="RPC0_shift+0.5*RPC_thick-RPC_shift"/>
+     <position name="RPC0_Al0_pos" z="RPC_thick*(0-(2-1)*0.5)+RPC0_shift+0.5*RPC_thick-RPC_shift"/>
+     <position name="RPC0_Al1_pos" z="RPC_thick*(1-(2-1)*0.5)+RPC0_shift+0.5*RPC_thick-RPC_shift"/>
+     <position name="RPC1_pos" z="RPC1_shift+0.5*RPC_thick-RPC_shift"/>
+     <position name="RPC1_Al0_pos" z="RPC_thick*(0-(2-1)*0.5)+RPC1_shift+0.5*RPC_thick-RPC_shift"/>
+     <position name="RPC1_Al1_pos" z="RPC_thick*(1-(2-1)*0.5)+RPC1_shift+0.5*RPC_thick-RPC_shift"/>
+	 <!-- ABOVE IS FOR RPC -->
+
+	<!-- BELOW IS FOR LG -->
+
+    <quantity name="LG_length" value="340" unit="mm" />
+    <quantity name="LG_height" value="122" unit="mm" />
+    <quantity name="LG_width0" value="113" unit="mm" />
+    <quantity name="LG_width1" value="135" unit="mm" />
+    <quantity name="LG_width1T" value="145.4824" unit="mm" />
+    <quantity name="LG_angle" value="3.7074" unit="degree"/>
+    <quantity name="LG_TransHorOff_shift" value="2." unit="mm" />
+    <quantity name="LG_protrusion_thick" value="40" unit="mm" />
+    <quantity name="LG_PMTr" value="38" unit="mm" />
+    <quantity name="LG_PMTl" value="120" unit="mm" />
+
+    <position name="LG_trap_pos1" x="0" y="0" z="-0.5*(LG_TransHorOff_shift+LG_length+LG_protrusion_thick+LG_PMTl-LG_length)"/>
+	<position name="LG_protrusion_pos" x="0" y="0" z="LG_length-0.5*(LG_TransHorOff_shift+LG_length+LG_protrusion_thick+LG_PMTl)+0.5*LG_protrusion_thick"/>
+	<position name="LG_PMT_pos" x="0" y="0" z="LG_length-0.5*(LG_TransHorOff_shift+LG_length+LG_protrusion_thick+LG_PMTl)+LG_protrusion_thick+0.5*LG_PMTl"/>
+
+	<position name="LG_block00_pos" x="(0.5*(LG_width0+LG_width1T)+LG_TransHorOff_shift+Tolerance_space)" y="LG_height*(0-1)+2.5*(0-1)" z="0."/>
+	<position name="LG_block01_pos" x="0" y="LG_height*(0-1)+2.5*(0-1)" z="0"/>
+	<position name="LG_block02_pos" x="-(0.5*(LG_width0+LG_width1T)+LG_TransHorOff_shift+Tolerance_space)" y="LG_height*(0-1)+2.5*(0-1)" z="0."/>
+	<rotation name="LG_block00_rot" x="0" y="-1.0*LG_angle" z="0" />
+	<rotation name="LG_block01_rot" x="0" y="0" z="0" />
+	<rotation name="LG_block02_rot" x="0" y="LG_angle" z="0" />
+	<position name="LG_block10_pos" x="(0.5*(LG_width0+LG_width1T)+LG_TransHorOff_shift+Tolerance_space)" y="LG_height*(1-1)+2.5*(1-1)" z="0."/>
+	<position name="LG_block11_pos" x="0" y="LG_height*(1-1)+2.5*(1-1)" z="0"/>
+	<position name="LG_block12_pos" x="-(0.5*(LG_width0+LG_width1T)+LG_TransHorOff_shift+Tolerance_space)" y="LG_height*(1-1)+2.5*(1-1)" z="0."/>
+	<rotation name="LG_block10_rot" x="0" y="-1.0*LG_angle" z="0" />
+	<rotation name="LG_block11_rot" x="0" y="0" z="0" />
+	<rotation name="LG_block12_rot" x="0" y="LG_angle" z="0" />
+	<position name="LG_block20_pos" x="(0.5*(LG_width0+LG_width1T)+LG_TransHorOff_shift+Tolerance_space)" y="LG_height*(2-1)+2.5*(2-1)" z="0."/>
+	<position name="LG_block21_pos" x="0" y="LG_height*(2-1)+2.5*(2-1)" z="0"/>
+	<position name="LG_block22_pos" x="-(0.5*(LG_width0+LG_width1T)+LG_TransHorOff_shift+Tolerance_space)" y="LG_height*(2-1)+2.5*(2-1)" z="0."/>
+	<rotation name="LG_block20_rot" x="0" y="-1.0*LG_angle" z="0" />
+	<rotation name="LG_block21_rot" x="0" y="0" z="0" />
+	<rotation name="LG_block22_rot" x="0" y="LG_angle" z="0" />
+	<quantity name="calor_length" value="520" unit="mm" />
+	<quantity name="calor_height" value="380" unit="mm" />
+	<quantity name="calor_width" value="900" unit="mm" />
+    <quantity name="calor_shift" value="4286.4" unit="mm" />
+    <position name="calor_pos" x="0" y="0" z="calor_shift+calor_length*0.5"/>
+
+	 <!-- ABOVE IS FOR LG -->
+
+  
 
 	<!-- ********** Refractive index ********** -->
 

--- a/ConstBase/Geometry/phase1c_Graphite_7S_nomag.gdml
+++ b/ConstBase/Geometry/phase1c_Graphite_7S_nomag.gdml
@@ -8,6 +8,2127 @@
 --> 
 
 <define>
+	
+	<constant name="DEG2RAD" value="pi/180." />
+	<quantity name="world_size" value="10000." unit="mm"/>
+	<quantity name="Tolerance_space" value="1." unit="mm" />
+	<position name="center" x="0" y="0" z="0" unit="mm"/>
+	
+    <!-- BELOW IS FOR T0 -->
+		
+	<quantity name="T0_length" value="280.0" unit="mm"/>
+	<quantity name="T0_width" value="210.0" unit="mm"/>
+	<quantity name="T0_height" value="300.0" unit="mm"/>
+	<quantity name="T0_shift" value="-267.5" unit="mm"/>
+	<quantity name="T0_acrylic_shift" value="40.0" unit="mm"/>
+	<position name="T0_pos" z="T0_shift+T0_acrylic_shift"/>
+
+	<quantity name="T0_acrylic_length" value="150.0" unit="mm"/>
+	<quantity name="T0_acrylic_width" value="3.0" unit="mm"/>
+	<quantity name="T0_acrylic_height" value="3.0" unit="mm"/>
+		
+	<position name="T0_acrylic0_pos" x="T0_acrylic_width*(0-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*0"/>
+	<position name="T0_acrylic1_pos" x="T0_acrylic_width*(1-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*1"/>
+	<position name="T0_acrylic2_pos" x="T0_acrylic_width*(2-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*0"/>
+	<position name="T0_acrylic3_pos" x="T0_acrylic_width*(3-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*1"/>
+	<position name="T0_acrylic4_pos" x="T0_acrylic_width*(4-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*0"/>
+	<position name="T0_acrylic5_pos" x="T0_acrylic_width*(5-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*1"/>
+	<position name="T0_acrylic6_pos" x="T0_acrylic_width*(6-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*0"/>
+	<position name="T0_acrylic7_pos" x="T0_acrylic_width*(7-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*1"/>
+	<position name="T0_acrylic8_pos" x="T0_acrylic_width*(8-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*0"/>
+	<position name="T0_acrylic9_pos" x="T0_acrylic_width*(9-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*1"/>
+	<position name="T0_acrylic10_pos" x="T0_acrylic_width*(10-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*0"/>
+	<position name="T0_acrylic11_pos" x="T0_acrylic_width*(11-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*1"/>
+	<position name="T0_acrylic12_pos" x="T0_acrylic_width*(12-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*0"/>
+	<position name="T0_acrylic13_pos" x="T0_acrylic_width*(13-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*1"/>
+	<position name="T0_acrylic14_pos" x="T0_acrylic_width*(14-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*0"/>
+	<position name="T0_acrylic15_pos" x="T0_acrylic_width*(15-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*1"/>
+	<position name="T0_acrylic16_pos" x="T0_acrylic_width*(16-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*0"/>
+	<position name="T0_acrylic17_pos" x="T0_acrylic_width*(17-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*1"/>
+	<position name="T0_acrylic18_pos" x="T0_acrylic_width*(18-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*0"/>
+	<position name="T0_acrylic19_pos" x="T0_acrylic_width*(19-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*1"/>
+	    
+    <rotation name="T0_union1_rot" x="90" unit="deg"/>
+	<rotation name="T0_acrylic_rot" x="-45" unit="deg"/>
+
+	<!-- ABOVE IS FOR T0 -->
+	<!-- BELOW IS FOR TARGET -->
+	    
+	    <quantity name="target_width" value="100.0" unit="mm"/>
+	    <quantity name="target_height" value="50.0" unit="mm"/>
+	    <quantity name="target_depth" value="20" unit="mm"/>
+	    
+	    <position name="target_pos" x="0" y="0" z="380.5"/>
+
+	 <!-- ABOVE IS FOR TARGET -->
+
+  <!-- BELOW IS FOR SSD -->
+
+	<quantity name="ssdD0_thick" value=".300" unit="mm"/>
+	<quantity name="ssdD0_height" value="38.46" unit="mm"/>
+	<quantity name="ssdD0_width" value="98.33" unit="mm"/>
+	
+	<quantity name="ssdD0_chanwidth" value="0.059999" unit="mm"/>
+	<quantity name="ssdD0_changap" value="0.000001" unit="mm"/>
+	
+	<quantity name="ssdD0_overlap" value="2.0" unit="mm"/>
+	<quantity name="ssd_bkpln_thick" value=".300" unit="mm"/>
+	
+	<quantity name="ssdStation0_shift" value="0" unit="mm"/>
+	<quantity name="ssdStation1_shift" value="281" unit="mm"/>
+	<quantity name="ssdStation2_shift" value="501" unit="mm"/>
+	<quantity name="ssdStation3_shift" value="615" unit="mm"/>
+	<quantity name="ssdStation4_shift" value="846" unit="mm"/>
+	<quantity name="ssdStation5_shift" value="1146.38" unit="mm"/>
+	<quantity name="ssdStation6_shift" value="1471.82" unit="mm"/>
+	
+	<quantity name="mount_thick" value="6.35" unit="mm" />
+	<quantity name="mount_width" value="115.98" unit="mm" />
+	<quantity name="mount_hole" value="80.00" unit="mm" />
+	<quantity name="mount_enclosure_size" value="200" unit="mm" />
+
+	<quantity name="Mylar_Window_thick" value="0.500" unit="mm" />
+	<quantity name="Mylar_shift" value="20" unit="mm"/>
+	    
+	<quantity name="ssdStationsingleLength" value="50" unit="mm" />
+	<quantity name="ssdStationsingleWidth" value="300" unit="mm" />
+	<quantity name="ssdStationsingleHeight" value="300" unit="mm" />
+	<position name="ssdStation0_pos" x="0" y="0" z="ssdStation0_shift+ssdD0_thick-0.5*mount_thick"/>
+
+	<position name="ssdsensor_0_0_0_pos" x="0" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_0_0_0_pos" x="0" y="0" z="0*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_0_0_0_rot" x="180.0*0" y="0" z="0" unit="deg"/>
+	<position name="ssdsensor_0_1_0_pos" x="0" y="0" z="(1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_0_1_0_pos" x="0" y="0" z="1*ssdD0_thick+(1-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_0_1_0_rot" x="180.0*1" y="0" z="90" unit="deg"/>
+	<position name="ssdStation1_pos" x="0" y="0" z="ssdStation1_shift+ssdD0_thick-0.5*mount_thick"/>
+
+	<position name="ssdsensor_1_0_0_pos" x="0" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_1_0_0_pos" x="0" y="0" z="0*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_1_0_0_rot" x="180.0*0" y="0" z="0" unit="deg"/>
+	<position name="ssdsensor_1_1_0_pos" x="0" y="0" z="(1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_1_1_0_pos" x="0" y="0" z="1*ssdD0_thick+(1-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_1_1_0_rot" x="180.0*1" y="0" z="90" unit="deg"/>
+	<position name="ssdStation2_pos" x="0" y="0" z="ssdStation2_shift+ssdD0_thick-0.5*mount_thick"/>
+
+	<position name="ssdsensor_2_0_0_pos" x="0" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_2_0_0_pos" x="0" y="0" z="0*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_2_0_0_rot" x="180.0*0" y="0" z="315" unit="deg"/>
+	<position name="ssdsensor_2_1_0_pos" x="0" y="0" z="(1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_2_1_0_pos" x="0" y="0" z="1*ssdD0_thick+(1-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_2_1_0_rot" x="180.0*0" y="0" z="0" unit="deg"/>
+	<position name="ssdsensor_2_2_0_pos" x="0" y="0" z="0.5*ssdD0_thick+ssd_bkpln_thick+0.5*mount_thick+0"/>
+	<position name="ssd_bkpln_2_2_0_pos" x="0" y="0" z="0.5*ssd_bkpln_thick+0.5*mount_thick+0"/>
+	<rotation name="ssdsensor_2_2_0_rot" x="180.0*1" y="0" z="90" unit="deg"/>
+	<position name="ssdStation3_pos" x="0" y="0" z="ssdStation3_shift+ssdD0_thick-0.5*mount_thick"/>
+
+	<position name="ssdsensor_3_0_0_pos" x="0" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_3_0_0_pos" x="0" y="0" z="0*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_3_0_0_rot" x="180.0*0" y="0" z="315" unit="deg"/>
+	<position name="ssdsensor_3_1_0_pos" x="0" y="0" z="(1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_3_1_0_pos" x="0" y="0" z="1*ssdD0_thick+(1-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_3_1_0_rot" x="180.0*0" y="0" z="0" unit="deg"/>
+	<position name="ssdsensor_3_2_0_pos" x="0" y="0" z="0.5*ssdD0_thick+ssd_bkpln_thick+0.5*mount_thick+0"/>
+	<position name="ssd_bkpln_3_2_0_pos" x="0" y="0" z="0.5*ssd_bkpln_thick+0.5*mount_thick+0"/>
+	<rotation name="ssdsensor_3_2_0_rot" x="180.0*1" y="0" z="90" unit="deg"/>
+	<position name="ssdStation4_pos" x="0" y="0" z="ssdStation4_shift+ssdD0_thick-0.5*mount_thick"/>
+
+	<position name="ssdsensor_4_0_0_pos" x="0" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_4_0_0_pos" x="0" y="0" z="0*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_4_0_0_rot" x="180.0*0" y="0" z="0" unit="deg"/>
+	<position name="ssdsensor_4_1_0_pos" x="0" y="0" z="(1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_4_1_0_pos" x="0" y="0" z="1*ssdD0_thick+(1-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_4_1_0_rot" x="180.0*1" y="0" z="90" unit="deg"/>
+	<position name="ssdStation5_pos" x="0" y="0" z="ssdStation5_shift+ssdD0_thick-0.5*mount_thick"/>
+
+	<position name="ssdsensor_5_0_0_pos" x="-18.23" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_5_0_0_pos" x="-18.23" y="0" z="0*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_5_0_0_rot" x="180.0*0" y="0" z="270" unit="deg"/>
+	<position name="ssdsensor_5_0_1_pos" x="18.23" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_5_0_1_pos" x="18.23" y="0" z="0*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_5_0_1_rot" x="180.0*0" y="0" z="90" unit="deg"/>
+	<position name="ssdsensor_5_1_0_pos" x="0" y="-18.23" z="(1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_5_1_0_pos" x="0" y="-18.23" z="1*ssdD0_thick+(1-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_5_1_0_rot" x="180.0*1" y="0" z="0" unit="deg"/>
+	<position name="ssdsensor_5_1_1_pos" x="0" y="18.23" z="(1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_5_1_1_pos" x="0" y="18.23" z="1*ssdD0_thick+(1-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_5_1_1_rot" x="180.0*1" y="0" z="180" unit="deg"/>
+	<position name="ssdsensor_5_2_0_pos" x="12.92" y="-12.92" z="0.5*ssdD0_thick+ssd_bkpln_thick+0.5*mount_thick+0"/>
+	<position name="ssd_bkpln_5_2_0_pos" x="12.92" y="-12.92" z="0.5*ssd_bkpln_thick+0.5*mount_thick+0"/>
+	<rotation name="ssdsensor_5_2_0_rot" x="180.0*1" y="0" z="45" unit="deg"/>
+	<position name="ssdsensor_5_2_1_pos" x="-12.92" y="12.92" z="0.5*ssdD0_thick+ssd_bkpln_thick+0.5*mount_thick+0"/>
+	<position name="ssd_bkpln_5_2_1_pos" x="-12.92" y="12.92" z="0.5*ssd_bkpln_thick+0.5*mount_thick+0"/>
+	<rotation name="ssdsensor_5_2_1_rot" x="180.0*1" y="0" z="225" unit="deg"/>
+	<position name="ssdStation6_pos" x="0" y="0" z="ssdStation6_shift+ssdD0_thick-0.5*mount_thick"/>
+
+	<position name="ssdsensor_6_0_0_pos" x="-18.23" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_6_0_0_pos" x="-18.23" y="0" z="0*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_6_0_0_rot" x="180.0*0" y="0" z="270" unit="deg"/>
+	<position name="ssdsensor_6_0_1_pos" x="18.23" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_6_0_1_pos" x="18.23" y="0" z="0*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_6_0_1_rot" x="180.0*0" y="0" z="90" unit="deg"/>
+	<position name="ssdsensor_6_1_0_pos" x="0" y="-18.23" z="(1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_6_1_0_pos" x="0" y="-18.23" z="1*ssdD0_thick+(1-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_6_1_0_rot" x="180.0*1" y="0" z="0" unit="deg"/>
+	<position name="ssdsensor_6_1_1_pos" x="0" y="18.23" z="(1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_6_1_1_pos" x="0" y="18.23" z="1*ssdD0_thick+(1-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_6_1_1_rot" x="180.0*1" y="0" z="180" unit="deg"/>
+	<position name="ssdsensor_6_2_0_pos" x="12.92" y="-12.92" z="0.5*ssdD0_thick+ssd_bkpln_thick+0.5*mount_thick+0"/>
+	<position name="ssd_bkpln_6_2_0_pos" x="12.92" y="-12.92" z="0.5*ssd_bkpln_thick+0.5*mount_thick+0"/>
+	<rotation name="ssdsensor_6_2_0_rot" x="180.0*1" y="0" z="45" unit="deg"/>
+	<position name="ssdsensor_6_2_1_pos" x="-12.92" y="12.92" z="0.5*ssdD0_thick+ssd_bkpln_thick+0.5*mount_thick+0"/>
+	<position name="ssd_bkpln_6_2_1_pos" x="-12.92" y="12.92" z="0.5*ssd_bkpln_thick+0.5*mount_thick+0"/>
+	<rotation name="ssdsensor_6_2_1_rot" x="180.0*1" y="0" z="225" unit="deg"/>
+	<position name="ssdmount_local_0_0_pos" x="0" y="0" z="0"/>
+	<position name="ssdmount_0_0_pos" x="0" y="0" z="0+0.5*mount_thick"/>
+	<rotation name="ssdmount_0_0_rot" x="-0.44" y="-2.02" unit="deg"/>
+	<position name="ssdmount_local_1_0_pos" x="0" y="0" z="0"/>
+	<position name="ssdmount_1_0_pos" x="0" y="0" z="0+0.5*mount_thick"/>
+	<rotation name="ssdmount_1_0_rot" x="0.24" y="-1.26" unit="deg"/>
+	<position name="ssdmount_local_2_0_pos" x="0" y="0" z="0"/>
+	<position name="ssdmount_2_0_pos" x="0" y="0" z="0+0.5*mount_thick"/>
+	<rotation name="ssdmount_2_0_rot" x="0" y="0" unit="deg"/>
+	<position name="ssdmount_local_2_1_pos" x="0" y="0" z="0"/>
+	<position name="ssdmount_2_1_pos" x="0" y="0" z="10+0.5*mount_thick"/>
+	<rotation name="ssdmount_2_1_rot" x="0" y="0" unit="deg"/>
+	<position name="ssdmount_local_3_0_pos" x="0" y="0" z="0"/>
+	<position name="ssdmount_3_0_pos" x="0" y="0" z="0+0.5*mount_thick"/>
+	<rotation name="ssdmount_3_0_rot" x="0" y="0" unit="deg"/>
+	<position name="ssdmount_local_3_1_pos" x="0" y="0" z="0"/>
+	<position name="ssdmount_3_1_pos" x="0" y="0" z="10+0.5*mount_thick"/>
+	<rotation name="ssdmount_3_1_rot" x="0" y="0" unit="deg"/>
+	<position name="ssdmount_local_4_0_pos" x="0" y="0" z="0"/>
+	<position name="ssdmount_4_0_pos" x="0" y="0" z="0+0.5*mount_thick"/>
+	<rotation name="ssdmount_4_0_rot" x="0" y="0" unit="deg"/>
+	<position name="ssdmount_local_5_0_pos" x="0" y="0" z="0"/>
+	<position name="ssdmount_5_0_pos" x="0" y="0" z="0+0.5*mount_thick"/>
+	<rotation name="ssdmount_5_0_rot" x="0" y="0" unit="deg"/>
+	<position name="ssdmount_local_5_1_pos" x="0" y="0" z="0"/>
+	<position name="ssdmount_5_1_pos" x="0" y="0" z="10+0.5*mount_thick"/>
+	<rotation name="ssdmount_5_1_rot" x="0" y="0" unit="deg"/>
+	<position name="ssdmount_local_6_0_pos" x="0" y="0" z="0"/>
+	<position name="ssdmount_6_0_pos" x="0" y="0" z="0+0.5*mount_thick"/>
+	<rotation name="ssdmount_6_0_rot" x="-0.06" y="-1.49" unit="deg"/>
+	<position name="ssdmount_local_6_1_pos" x="0" y="0" z="0"/>
+	<position name="ssdmount_6_1_pos" x="0" y="0" z="10+0.5*mount_thick"/>
+	<rotation name="ssdmount_6_1_rot" x="-0.06" y="-1.49" unit="deg"/>
+
+	<position name="ssd_USMylarWindow_pos" x="0" y="0" z="-1*Mylar_shift"/>
+	<position name="ssd_DSMylarWindow_pos" x="0" y="0" z="Mylar_shift"/>
+
+	<position name="ssd_mount_u1_pos" x="70" y="0" z="0"/>
+	<rotation name="ssd_mount_u1_rot" y="-90" unit="deg"/>
+	<position name="ssd_mount_u2_pos" x="0" y="-70" z="0"/>
+	<rotation name="ssd_mount_u2_rot" y="-90" z="-90" unit="deg"/>
+	<rotation name="ssd_mount_u3_rot" z="90" unit="deg"/>
+	<position name="ssd_mount_u4_pos" x="80.1" y="-80.4"/>
+	<rotation name="ssd_mount_u4_rot" y="-90" z="135" unit="deg"/>
+	<position name="ssd_mount_out_pos1" z="0.5*mount_thick" unit="mm" />
+	<position name="ssd_mount_out_pos2" z="-0.5*mount_thick" unit="mm" />
+
+    <quantity name="ssdStationrotateLength" value="50" unit="mm" />
+	<quantity name="ssdStationrotateWidth" value="300" unit="mm" />
+	<quantity name="ssdStationrotateHeight" value="300" unit="mm" />
+	<quantity name="ssdStationdouble3plLength" value="100" unit="mm" />
+	<quantity name="ssdStationdouble3plWidth" value="450" unit="mm" />
+	<quantity name="ssdStationdouble3plHeight" value="450" unit="mm" />
+	<quantity name="ssdStationdouble2plLength" value="100" unit="mm" />
+	<quantity name="ssdStationdouble2plWidth" value="300" unit="mm" />
+	<quantity name="ssdStationdouble2plHeight" value="300" unit="mm" />
+
+	<position name="ssd_chan_0_pos" x="0" y="(-319.5+0)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_1_pos" x="0" y="(-319.5+1)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_2_pos" x="0" y="(-319.5+2)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_3_pos" x="0" y="(-319.5+3)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_4_pos" x="0" y="(-319.5+4)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_5_pos" x="0" y="(-319.5+5)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_6_pos" x="0" y="(-319.5+6)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_7_pos" x="0" y="(-319.5+7)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_8_pos" x="0" y="(-319.5+8)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_9_pos" x="0" y="(-319.5+9)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_10_pos" x="0" y="(-319.5+10)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_11_pos" x="0" y="(-319.5+11)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_12_pos" x="0" y="(-319.5+12)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_13_pos" x="0" y="(-319.5+13)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_14_pos" x="0" y="(-319.5+14)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_15_pos" x="0" y="(-319.5+15)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_16_pos" x="0" y="(-319.5+16)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_17_pos" x="0" y="(-319.5+17)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_18_pos" x="0" y="(-319.5+18)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_19_pos" x="0" y="(-319.5+19)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_20_pos" x="0" y="(-319.5+20)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_21_pos" x="0" y="(-319.5+21)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_22_pos" x="0" y="(-319.5+22)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_23_pos" x="0" y="(-319.5+23)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_24_pos" x="0" y="(-319.5+24)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_25_pos" x="0" y="(-319.5+25)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_26_pos" x="0" y="(-319.5+26)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_27_pos" x="0" y="(-319.5+27)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_28_pos" x="0" y="(-319.5+28)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_29_pos" x="0" y="(-319.5+29)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_30_pos" x="0" y="(-319.5+30)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_31_pos" x="0" y="(-319.5+31)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_32_pos" x="0" y="(-319.5+32)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_33_pos" x="0" y="(-319.5+33)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_34_pos" x="0" y="(-319.5+34)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_35_pos" x="0" y="(-319.5+35)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_36_pos" x="0" y="(-319.5+36)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_37_pos" x="0" y="(-319.5+37)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_38_pos" x="0" y="(-319.5+38)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_39_pos" x="0" y="(-319.5+39)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_40_pos" x="0" y="(-319.5+40)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_41_pos" x="0" y="(-319.5+41)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_42_pos" x="0" y="(-319.5+42)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_43_pos" x="0" y="(-319.5+43)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_44_pos" x="0" y="(-319.5+44)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_45_pos" x="0" y="(-319.5+45)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_46_pos" x="0" y="(-319.5+46)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_47_pos" x="0" y="(-319.5+47)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_48_pos" x="0" y="(-319.5+48)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_49_pos" x="0" y="(-319.5+49)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_50_pos" x="0" y="(-319.5+50)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_51_pos" x="0" y="(-319.5+51)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_52_pos" x="0" y="(-319.5+52)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_53_pos" x="0" y="(-319.5+53)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_54_pos" x="0" y="(-319.5+54)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_55_pos" x="0" y="(-319.5+55)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_56_pos" x="0" y="(-319.5+56)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_57_pos" x="0" y="(-319.5+57)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_58_pos" x="0" y="(-319.5+58)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_59_pos" x="0" y="(-319.5+59)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_60_pos" x="0" y="(-319.5+60)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_61_pos" x="0" y="(-319.5+61)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_62_pos" x="0" y="(-319.5+62)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_63_pos" x="0" y="(-319.5+63)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_64_pos" x="0" y="(-319.5+64)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_65_pos" x="0" y="(-319.5+65)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_66_pos" x="0" y="(-319.5+66)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_67_pos" x="0" y="(-319.5+67)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_68_pos" x="0" y="(-319.5+68)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_69_pos" x="0" y="(-319.5+69)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_70_pos" x="0" y="(-319.5+70)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_71_pos" x="0" y="(-319.5+71)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_72_pos" x="0" y="(-319.5+72)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_73_pos" x="0" y="(-319.5+73)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_74_pos" x="0" y="(-319.5+74)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_75_pos" x="0" y="(-319.5+75)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_76_pos" x="0" y="(-319.5+76)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_77_pos" x="0" y="(-319.5+77)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_78_pos" x="0" y="(-319.5+78)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_79_pos" x="0" y="(-319.5+79)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_80_pos" x="0" y="(-319.5+80)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_81_pos" x="0" y="(-319.5+81)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_82_pos" x="0" y="(-319.5+82)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_83_pos" x="0" y="(-319.5+83)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_84_pos" x="0" y="(-319.5+84)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_85_pos" x="0" y="(-319.5+85)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_86_pos" x="0" y="(-319.5+86)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_87_pos" x="0" y="(-319.5+87)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_88_pos" x="0" y="(-319.5+88)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_89_pos" x="0" y="(-319.5+89)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_90_pos" x="0" y="(-319.5+90)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_91_pos" x="0" y="(-319.5+91)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_92_pos" x="0" y="(-319.5+92)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_93_pos" x="0" y="(-319.5+93)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_94_pos" x="0" y="(-319.5+94)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_95_pos" x="0" y="(-319.5+95)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_96_pos" x="0" y="(-319.5+96)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_97_pos" x="0" y="(-319.5+97)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_98_pos" x="0" y="(-319.5+98)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_99_pos" x="0" y="(-319.5+99)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_100_pos" x="0" y="(-319.5+100)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_101_pos" x="0" y="(-319.5+101)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_102_pos" x="0" y="(-319.5+102)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_103_pos" x="0" y="(-319.5+103)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_104_pos" x="0" y="(-319.5+104)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_105_pos" x="0" y="(-319.5+105)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_106_pos" x="0" y="(-319.5+106)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_107_pos" x="0" y="(-319.5+107)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_108_pos" x="0" y="(-319.5+108)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_109_pos" x="0" y="(-319.5+109)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_110_pos" x="0" y="(-319.5+110)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_111_pos" x="0" y="(-319.5+111)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_112_pos" x="0" y="(-319.5+112)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_113_pos" x="0" y="(-319.5+113)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_114_pos" x="0" y="(-319.5+114)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_115_pos" x="0" y="(-319.5+115)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_116_pos" x="0" y="(-319.5+116)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_117_pos" x="0" y="(-319.5+117)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_118_pos" x="0" y="(-319.5+118)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_119_pos" x="0" y="(-319.5+119)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_120_pos" x="0" y="(-319.5+120)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_121_pos" x="0" y="(-319.5+121)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_122_pos" x="0" y="(-319.5+122)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_123_pos" x="0" y="(-319.5+123)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_124_pos" x="0" y="(-319.5+124)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_125_pos" x="0" y="(-319.5+125)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_126_pos" x="0" y="(-319.5+126)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_127_pos" x="0" y="(-319.5+127)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_128_pos" x="0" y="(-319.5+128)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_129_pos" x="0" y="(-319.5+129)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_130_pos" x="0" y="(-319.5+130)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_131_pos" x="0" y="(-319.5+131)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_132_pos" x="0" y="(-319.5+132)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_133_pos" x="0" y="(-319.5+133)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_134_pos" x="0" y="(-319.5+134)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_135_pos" x="0" y="(-319.5+135)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_136_pos" x="0" y="(-319.5+136)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_137_pos" x="0" y="(-319.5+137)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_138_pos" x="0" y="(-319.5+138)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_139_pos" x="0" y="(-319.5+139)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_140_pos" x="0" y="(-319.5+140)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_141_pos" x="0" y="(-319.5+141)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_142_pos" x="0" y="(-319.5+142)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_143_pos" x="0" y="(-319.5+143)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_144_pos" x="0" y="(-319.5+144)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_145_pos" x="0" y="(-319.5+145)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_146_pos" x="0" y="(-319.5+146)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_147_pos" x="0" y="(-319.5+147)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_148_pos" x="0" y="(-319.5+148)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_149_pos" x="0" y="(-319.5+149)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_150_pos" x="0" y="(-319.5+150)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_151_pos" x="0" y="(-319.5+151)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_152_pos" x="0" y="(-319.5+152)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_153_pos" x="0" y="(-319.5+153)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_154_pos" x="0" y="(-319.5+154)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_155_pos" x="0" y="(-319.5+155)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_156_pos" x="0" y="(-319.5+156)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_157_pos" x="0" y="(-319.5+157)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_158_pos" x="0" y="(-319.5+158)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_159_pos" x="0" y="(-319.5+159)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_160_pos" x="0" y="(-319.5+160)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_161_pos" x="0" y="(-319.5+161)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_162_pos" x="0" y="(-319.5+162)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_163_pos" x="0" y="(-319.5+163)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_164_pos" x="0" y="(-319.5+164)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_165_pos" x="0" y="(-319.5+165)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_166_pos" x="0" y="(-319.5+166)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_167_pos" x="0" y="(-319.5+167)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_168_pos" x="0" y="(-319.5+168)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_169_pos" x="0" y="(-319.5+169)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_170_pos" x="0" y="(-319.5+170)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_171_pos" x="0" y="(-319.5+171)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_172_pos" x="0" y="(-319.5+172)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_173_pos" x="0" y="(-319.5+173)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_174_pos" x="0" y="(-319.5+174)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_175_pos" x="0" y="(-319.5+175)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_176_pos" x="0" y="(-319.5+176)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_177_pos" x="0" y="(-319.5+177)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_178_pos" x="0" y="(-319.5+178)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_179_pos" x="0" y="(-319.5+179)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_180_pos" x="0" y="(-319.5+180)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_181_pos" x="0" y="(-319.5+181)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_182_pos" x="0" y="(-319.5+182)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_183_pos" x="0" y="(-319.5+183)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_184_pos" x="0" y="(-319.5+184)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_185_pos" x="0" y="(-319.5+185)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_186_pos" x="0" y="(-319.5+186)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_187_pos" x="0" y="(-319.5+187)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_188_pos" x="0" y="(-319.5+188)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_189_pos" x="0" y="(-319.5+189)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_190_pos" x="0" y="(-319.5+190)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_191_pos" x="0" y="(-319.5+191)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_192_pos" x="0" y="(-319.5+192)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_193_pos" x="0" y="(-319.5+193)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_194_pos" x="0" y="(-319.5+194)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_195_pos" x="0" y="(-319.5+195)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_196_pos" x="0" y="(-319.5+196)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_197_pos" x="0" y="(-319.5+197)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_198_pos" x="0" y="(-319.5+198)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_199_pos" x="0" y="(-319.5+199)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_200_pos" x="0" y="(-319.5+200)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_201_pos" x="0" y="(-319.5+201)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_202_pos" x="0" y="(-319.5+202)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_203_pos" x="0" y="(-319.5+203)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_204_pos" x="0" y="(-319.5+204)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_205_pos" x="0" y="(-319.5+205)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_206_pos" x="0" y="(-319.5+206)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_207_pos" x="0" y="(-319.5+207)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_208_pos" x="0" y="(-319.5+208)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_209_pos" x="0" y="(-319.5+209)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_210_pos" x="0" y="(-319.5+210)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_211_pos" x="0" y="(-319.5+211)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_212_pos" x="0" y="(-319.5+212)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_213_pos" x="0" y="(-319.5+213)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_214_pos" x="0" y="(-319.5+214)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_215_pos" x="0" y="(-319.5+215)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_216_pos" x="0" y="(-319.5+216)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_217_pos" x="0" y="(-319.5+217)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_218_pos" x="0" y="(-319.5+218)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_219_pos" x="0" y="(-319.5+219)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_220_pos" x="0" y="(-319.5+220)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_221_pos" x="0" y="(-319.5+221)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_222_pos" x="0" y="(-319.5+222)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_223_pos" x="0" y="(-319.5+223)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_224_pos" x="0" y="(-319.5+224)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_225_pos" x="0" y="(-319.5+225)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_226_pos" x="0" y="(-319.5+226)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_227_pos" x="0" y="(-319.5+227)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_228_pos" x="0" y="(-319.5+228)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_229_pos" x="0" y="(-319.5+229)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_230_pos" x="0" y="(-319.5+230)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_231_pos" x="0" y="(-319.5+231)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_232_pos" x="0" y="(-319.5+232)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_233_pos" x="0" y="(-319.5+233)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_234_pos" x="0" y="(-319.5+234)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_235_pos" x="0" y="(-319.5+235)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_236_pos" x="0" y="(-319.5+236)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_237_pos" x="0" y="(-319.5+237)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_238_pos" x="0" y="(-319.5+238)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_239_pos" x="0" y="(-319.5+239)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_240_pos" x="0" y="(-319.5+240)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_241_pos" x="0" y="(-319.5+241)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_242_pos" x="0" y="(-319.5+242)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_243_pos" x="0" y="(-319.5+243)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_244_pos" x="0" y="(-319.5+244)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_245_pos" x="0" y="(-319.5+245)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_246_pos" x="0" y="(-319.5+246)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_247_pos" x="0" y="(-319.5+247)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_248_pos" x="0" y="(-319.5+248)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_249_pos" x="0" y="(-319.5+249)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_250_pos" x="0" y="(-319.5+250)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_251_pos" x="0" y="(-319.5+251)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_252_pos" x="0" y="(-319.5+252)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_253_pos" x="0" y="(-319.5+253)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_254_pos" x="0" y="(-319.5+254)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_255_pos" x="0" y="(-319.5+255)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_256_pos" x="0" y="(-319.5+256)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_257_pos" x="0" y="(-319.5+257)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_258_pos" x="0" y="(-319.5+258)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_259_pos" x="0" y="(-319.5+259)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_260_pos" x="0" y="(-319.5+260)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_261_pos" x="0" y="(-319.5+261)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_262_pos" x="0" y="(-319.5+262)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_263_pos" x="0" y="(-319.5+263)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_264_pos" x="0" y="(-319.5+264)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_265_pos" x="0" y="(-319.5+265)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_266_pos" x="0" y="(-319.5+266)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_267_pos" x="0" y="(-319.5+267)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_268_pos" x="0" y="(-319.5+268)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_269_pos" x="0" y="(-319.5+269)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_270_pos" x="0" y="(-319.5+270)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_271_pos" x="0" y="(-319.5+271)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_272_pos" x="0" y="(-319.5+272)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_273_pos" x="0" y="(-319.5+273)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_274_pos" x="0" y="(-319.5+274)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_275_pos" x="0" y="(-319.5+275)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_276_pos" x="0" y="(-319.5+276)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_277_pos" x="0" y="(-319.5+277)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_278_pos" x="0" y="(-319.5+278)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_279_pos" x="0" y="(-319.5+279)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_280_pos" x="0" y="(-319.5+280)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_281_pos" x="0" y="(-319.5+281)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_282_pos" x="0" y="(-319.5+282)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_283_pos" x="0" y="(-319.5+283)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_284_pos" x="0" y="(-319.5+284)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_285_pos" x="0" y="(-319.5+285)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_286_pos" x="0" y="(-319.5+286)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_287_pos" x="0" y="(-319.5+287)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_288_pos" x="0" y="(-319.5+288)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_289_pos" x="0" y="(-319.5+289)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_290_pos" x="0" y="(-319.5+290)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_291_pos" x="0" y="(-319.5+291)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_292_pos" x="0" y="(-319.5+292)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_293_pos" x="0" y="(-319.5+293)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_294_pos" x="0" y="(-319.5+294)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_295_pos" x="0" y="(-319.5+295)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_296_pos" x="0" y="(-319.5+296)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_297_pos" x="0" y="(-319.5+297)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_298_pos" x="0" y="(-319.5+298)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_299_pos" x="0" y="(-319.5+299)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_300_pos" x="0" y="(-319.5+300)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_301_pos" x="0" y="(-319.5+301)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_302_pos" x="0" y="(-319.5+302)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_303_pos" x="0" y="(-319.5+303)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_304_pos" x="0" y="(-319.5+304)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_305_pos" x="0" y="(-319.5+305)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_306_pos" x="0" y="(-319.5+306)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_307_pos" x="0" y="(-319.5+307)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_308_pos" x="0" y="(-319.5+308)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_309_pos" x="0" y="(-319.5+309)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_310_pos" x="0" y="(-319.5+310)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_311_pos" x="0" y="(-319.5+311)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_312_pos" x="0" y="(-319.5+312)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_313_pos" x="0" y="(-319.5+313)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_314_pos" x="0" y="(-319.5+314)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_315_pos" x="0" y="(-319.5+315)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_316_pos" x="0" y="(-319.5+316)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_317_pos" x="0" y="(-319.5+317)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_318_pos" x="0" y="(-319.5+318)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_319_pos" x="0" y="(-319.5+319)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_320_pos" x="0" y="(-319.5+320)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_321_pos" x="0" y="(-319.5+321)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_322_pos" x="0" y="(-319.5+322)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_323_pos" x="0" y="(-319.5+323)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_324_pos" x="0" y="(-319.5+324)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_325_pos" x="0" y="(-319.5+325)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_326_pos" x="0" y="(-319.5+326)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_327_pos" x="0" y="(-319.5+327)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_328_pos" x="0" y="(-319.5+328)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_329_pos" x="0" y="(-319.5+329)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_330_pos" x="0" y="(-319.5+330)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_331_pos" x="0" y="(-319.5+331)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_332_pos" x="0" y="(-319.5+332)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_333_pos" x="0" y="(-319.5+333)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_334_pos" x="0" y="(-319.5+334)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_335_pos" x="0" y="(-319.5+335)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_336_pos" x="0" y="(-319.5+336)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_337_pos" x="0" y="(-319.5+337)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_338_pos" x="0" y="(-319.5+338)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_339_pos" x="0" y="(-319.5+339)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_340_pos" x="0" y="(-319.5+340)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_341_pos" x="0" y="(-319.5+341)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_342_pos" x="0" y="(-319.5+342)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_343_pos" x="0" y="(-319.5+343)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_344_pos" x="0" y="(-319.5+344)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_345_pos" x="0" y="(-319.5+345)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_346_pos" x="0" y="(-319.5+346)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_347_pos" x="0" y="(-319.5+347)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_348_pos" x="0" y="(-319.5+348)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_349_pos" x="0" y="(-319.5+349)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_350_pos" x="0" y="(-319.5+350)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_351_pos" x="0" y="(-319.5+351)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_352_pos" x="0" y="(-319.5+352)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_353_pos" x="0" y="(-319.5+353)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_354_pos" x="0" y="(-319.5+354)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_355_pos" x="0" y="(-319.5+355)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_356_pos" x="0" y="(-319.5+356)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_357_pos" x="0" y="(-319.5+357)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_358_pos" x="0" y="(-319.5+358)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_359_pos" x="0" y="(-319.5+359)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_360_pos" x="0" y="(-319.5+360)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_361_pos" x="0" y="(-319.5+361)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_362_pos" x="0" y="(-319.5+362)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_363_pos" x="0" y="(-319.5+363)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_364_pos" x="0" y="(-319.5+364)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_365_pos" x="0" y="(-319.5+365)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_366_pos" x="0" y="(-319.5+366)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_367_pos" x="0" y="(-319.5+367)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_368_pos" x="0" y="(-319.5+368)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_369_pos" x="0" y="(-319.5+369)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_370_pos" x="0" y="(-319.5+370)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_371_pos" x="0" y="(-319.5+371)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_372_pos" x="0" y="(-319.5+372)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_373_pos" x="0" y="(-319.5+373)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_374_pos" x="0" y="(-319.5+374)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_375_pos" x="0" y="(-319.5+375)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_376_pos" x="0" y="(-319.5+376)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_377_pos" x="0" y="(-319.5+377)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_378_pos" x="0" y="(-319.5+378)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_379_pos" x="0" y="(-319.5+379)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_380_pos" x="0" y="(-319.5+380)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_381_pos" x="0" y="(-319.5+381)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_382_pos" x="0" y="(-319.5+382)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_383_pos" x="0" y="(-319.5+383)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_384_pos" x="0" y="(-319.5+384)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_385_pos" x="0" y="(-319.5+385)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_386_pos" x="0" y="(-319.5+386)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_387_pos" x="0" y="(-319.5+387)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_388_pos" x="0" y="(-319.5+388)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_389_pos" x="0" y="(-319.5+389)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_390_pos" x="0" y="(-319.5+390)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_391_pos" x="0" y="(-319.5+391)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_392_pos" x="0" y="(-319.5+392)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_393_pos" x="0" y="(-319.5+393)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_394_pos" x="0" y="(-319.5+394)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_395_pos" x="0" y="(-319.5+395)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_396_pos" x="0" y="(-319.5+396)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_397_pos" x="0" y="(-319.5+397)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_398_pos" x="0" y="(-319.5+398)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_399_pos" x="0" y="(-319.5+399)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_400_pos" x="0" y="(-319.5+400)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_401_pos" x="0" y="(-319.5+401)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_402_pos" x="0" y="(-319.5+402)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_403_pos" x="0" y="(-319.5+403)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_404_pos" x="0" y="(-319.5+404)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_405_pos" x="0" y="(-319.5+405)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_406_pos" x="0" y="(-319.5+406)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_407_pos" x="0" y="(-319.5+407)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_408_pos" x="0" y="(-319.5+408)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_409_pos" x="0" y="(-319.5+409)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_410_pos" x="0" y="(-319.5+410)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_411_pos" x="0" y="(-319.5+411)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_412_pos" x="0" y="(-319.5+412)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_413_pos" x="0" y="(-319.5+413)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_414_pos" x="0" y="(-319.5+414)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_415_pos" x="0" y="(-319.5+415)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_416_pos" x="0" y="(-319.5+416)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_417_pos" x="0" y="(-319.5+417)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_418_pos" x="0" y="(-319.5+418)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_419_pos" x="0" y="(-319.5+419)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_420_pos" x="0" y="(-319.5+420)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_421_pos" x="0" y="(-319.5+421)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_422_pos" x="0" y="(-319.5+422)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_423_pos" x="0" y="(-319.5+423)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_424_pos" x="0" y="(-319.5+424)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_425_pos" x="0" y="(-319.5+425)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_426_pos" x="0" y="(-319.5+426)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_427_pos" x="0" y="(-319.5+427)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_428_pos" x="0" y="(-319.5+428)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_429_pos" x="0" y="(-319.5+429)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_430_pos" x="0" y="(-319.5+430)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_431_pos" x="0" y="(-319.5+431)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_432_pos" x="0" y="(-319.5+432)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_433_pos" x="0" y="(-319.5+433)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_434_pos" x="0" y="(-319.5+434)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_435_pos" x="0" y="(-319.5+435)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_436_pos" x="0" y="(-319.5+436)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_437_pos" x="0" y="(-319.5+437)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_438_pos" x="0" y="(-319.5+438)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_439_pos" x="0" y="(-319.5+439)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_440_pos" x="0" y="(-319.5+440)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_441_pos" x="0" y="(-319.5+441)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_442_pos" x="0" y="(-319.5+442)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_443_pos" x="0" y="(-319.5+443)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_444_pos" x="0" y="(-319.5+444)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_445_pos" x="0" y="(-319.5+445)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_446_pos" x="0" y="(-319.5+446)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_447_pos" x="0" y="(-319.5+447)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_448_pos" x="0" y="(-319.5+448)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_449_pos" x="0" y="(-319.5+449)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_450_pos" x="0" y="(-319.5+450)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_451_pos" x="0" y="(-319.5+451)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_452_pos" x="0" y="(-319.5+452)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_453_pos" x="0" y="(-319.5+453)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_454_pos" x="0" y="(-319.5+454)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_455_pos" x="0" y="(-319.5+455)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_456_pos" x="0" y="(-319.5+456)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_457_pos" x="0" y="(-319.5+457)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_458_pos" x="0" y="(-319.5+458)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_459_pos" x="0" y="(-319.5+459)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_460_pos" x="0" y="(-319.5+460)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_461_pos" x="0" y="(-319.5+461)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_462_pos" x="0" y="(-319.5+462)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_463_pos" x="0" y="(-319.5+463)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_464_pos" x="0" y="(-319.5+464)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_465_pos" x="0" y="(-319.5+465)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_466_pos" x="0" y="(-319.5+466)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_467_pos" x="0" y="(-319.5+467)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_468_pos" x="0" y="(-319.5+468)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_469_pos" x="0" y="(-319.5+469)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_470_pos" x="0" y="(-319.5+470)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_471_pos" x="0" y="(-319.5+471)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_472_pos" x="0" y="(-319.5+472)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_473_pos" x="0" y="(-319.5+473)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_474_pos" x="0" y="(-319.5+474)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_475_pos" x="0" y="(-319.5+475)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_476_pos" x="0" y="(-319.5+476)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_477_pos" x="0" y="(-319.5+477)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_478_pos" x="0" y="(-319.5+478)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_479_pos" x="0" y="(-319.5+479)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_480_pos" x="0" y="(-319.5+480)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_481_pos" x="0" y="(-319.5+481)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_482_pos" x="0" y="(-319.5+482)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_483_pos" x="0" y="(-319.5+483)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_484_pos" x="0" y="(-319.5+484)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_485_pos" x="0" y="(-319.5+485)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_486_pos" x="0" y="(-319.5+486)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_487_pos" x="0" y="(-319.5+487)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_488_pos" x="0" y="(-319.5+488)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_489_pos" x="0" y="(-319.5+489)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_490_pos" x="0" y="(-319.5+490)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_491_pos" x="0" y="(-319.5+491)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_492_pos" x="0" y="(-319.5+492)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_493_pos" x="0" y="(-319.5+493)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_494_pos" x="0" y="(-319.5+494)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_495_pos" x="0" y="(-319.5+495)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_496_pos" x="0" y="(-319.5+496)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_497_pos" x="0" y="(-319.5+497)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_498_pos" x="0" y="(-319.5+498)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_499_pos" x="0" y="(-319.5+499)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_500_pos" x="0" y="(-319.5+500)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_501_pos" x="0" y="(-319.5+501)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_502_pos" x="0" y="(-319.5+502)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_503_pos" x="0" y="(-319.5+503)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_504_pos" x="0" y="(-319.5+504)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_505_pos" x="0" y="(-319.5+505)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_506_pos" x="0" y="(-319.5+506)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_507_pos" x="0" y="(-319.5+507)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_508_pos" x="0" y="(-319.5+508)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_509_pos" x="0" y="(-319.5+509)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_510_pos" x="0" y="(-319.5+510)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_511_pos" x="0" y="(-319.5+511)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_512_pos" x="0" y="(-319.5+512)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_513_pos" x="0" y="(-319.5+513)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_514_pos" x="0" y="(-319.5+514)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_515_pos" x="0" y="(-319.5+515)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_516_pos" x="0" y="(-319.5+516)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_517_pos" x="0" y="(-319.5+517)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_518_pos" x="0" y="(-319.5+518)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_519_pos" x="0" y="(-319.5+519)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_520_pos" x="0" y="(-319.5+520)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_521_pos" x="0" y="(-319.5+521)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_522_pos" x="0" y="(-319.5+522)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_523_pos" x="0" y="(-319.5+523)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_524_pos" x="0" y="(-319.5+524)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_525_pos" x="0" y="(-319.5+525)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_526_pos" x="0" y="(-319.5+526)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_527_pos" x="0" y="(-319.5+527)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_528_pos" x="0" y="(-319.5+528)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_529_pos" x="0" y="(-319.5+529)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_530_pos" x="0" y="(-319.5+530)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_531_pos" x="0" y="(-319.5+531)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_532_pos" x="0" y="(-319.5+532)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_533_pos" x="0" y="(-319.5+533)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_534_pos" x="0" y="(-319.5+534)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_535_pos" x="0" y="(-319.5+535)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_536_pos" x="0" y="(-319.5+536)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_537_pos" x="0" y="(-319.5+537)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_538_pos" x="0" y="(-319.5+538)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_539_pos" x="0" y="(-319.5+539)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_540_pos" x="0" y="(-319.5+540)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_541_pos" x="0" y="(-319.5+541)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_542_pos" x="0" y="(-319.5+542)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_543_pos" x="0" y="(-319.5+543)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_544_pos" x="0" y="(-319.5+544)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_545_pos" x="0" y="(-319.5+545)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_546_pos" x="0" y="(-319.5+546)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_547_pos" x="0" y="(-319.5+547)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_548_pos" x="0" y="(-319.5+548)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_549_pos" x="0" y="(-319.5+549)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_550_pos" x="0" y="(-319.5+550)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_551_pos" x="0" y="(-319.5+551)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_552_pos" x="0" y="(-319.5+552)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_553_pos" x="0" y="(-319.5+553)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_554_pos" x="0" y="(-319.5+554)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_555_pos" x="0" y="(-319.5+555)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_556_pos" x="0" y="(-319.5+556)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_557_pos" x="0" y="(-319.5+557)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_558_pos" x="0" y="(-319.5+558)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_559_pos" x="0" y="(-319.5+559)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_560_pos" x="0" y="(-319.5+560)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_561_pos" x="0" y="(-319.5+561)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_562_pos" x="0" y="(-319.5+562)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_563_pos" x="0" y="(-319.5+563)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_564_pos" x="0" y="(-319.5+564)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_565_pos" x="0" y="(-319.5+565)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_566_pos" x="0" y="(-319.5+566)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_567_pos" x="0" y="(-319.5+567)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_568_pos" x="0" y="(-319.5+568)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_569_pos" x="0" y="(-319.5+569)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_570_pos" x="0" y="(-319.5+570)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_571_pos" x="0" y="(-319.5+571)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_572_pos" x="0" y="(-319.5+572)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_573_pos" x="0" y="(-319.5+573)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_574_pos" x="0" y="(-319.5+574)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_575_pos" x="0" y="(-319.5+575)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_576_pos" x="0" y="(-319.5+576)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_577_pos" x="0" y="(-319.5+577)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_578_pos" x="0" y="(-319.5+578)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_579_pos" x="0" y="(-319.5+579)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_580_pos" x="0" y="(-319.5+580)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_581_pos" x="0" y="(-319.5+581)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_582_pos" x="0" y="(-319.5+582)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_583_pos" x="0" y="(-319.5+583)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_584_pos" x="0" y="(-319.5+584)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_585_pos" x="0" y="(-319.5+585)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_586_pos" x="0" y="(-319.5+586)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_587_pos" x="0" y="(-319.5+587)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_588_pos" x="0" y="(-319.5+588)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_589_pos" x="0" y="(-319.5+589)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_590_pos" x="0" y="(-319.5+590)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_591_pos" x="0" y="(-319.5+591)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_592_pos" x="0" y="(-319.5+592)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_593_pos" x="0" y="(-319.5+593)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_594_pos" x="0" y="(-319.5+594)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_595_pos" x="0" y="(-319.5+595)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_596_pos" x="0" y="(-319.5+596)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_597_pos" x="0" y="(-319.5+597)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_598_pos" x="0" y="(-319.5+598)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_599_pos" x="0" y="(-319.5+599)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_600_pos" x="0" y="(-319.5+600)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_601_pos" x="0" y="(-319.5+601)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_602_pos" x="0" y="(-319.5+602)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_603_pos" x="0" y="(-319.5+603)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_604_pos" x="0" y="(-319.5+604)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_605_pos" x="0" y="(-319.5+605)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_606_pos" x="0" y="(-319.5+606)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_607_pos" x="0" y="(-319.5+607)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_608_pos" x="0" y="(-319.5+608)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_609_pos" x="0" y="(-319.5+609)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_610_pos" x="0" y="(-319.5+610)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_611_pos" x="0" y="(-319.5+611)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_612_pos" x="0" y="(-319.5+612)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_613_pos" x="0" y="(-319.5+613)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_614_pos" x="0" y="(-319.5+614)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_615_pos" x="0" y="(-319.5+615)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_616_pos" x="0" y="(-319.5+616)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_617_pos" x="0" y="(-319.5+617)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_618_pos" x="0" y="(-319.5+618)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_619_pos" x="0" y="(-319.5+619)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_620_pos" x="0" y="(-319.5+620)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_621_pos" x="0" y="(-319.5+621)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_622_pos" x="0" y="(-319.5+622)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_623_pos" x="0" y="(-319.5+623)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_624_pos" x="0" y="(-319.5+624)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_625_pos" x="0" y="(-319.5+625)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_626_pos" x="0" y="(-319.5+626)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_627_pos" x="0" y="(-319.5+627)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_628_pos" x="0" y="(-319.5+628)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_629_pos" x="0" y="(-319.5+629)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_630_pos" x="0" y="(-319.5+630)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_631_pos" x="0" y="(-319.5+631)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_632_pos" x="0" y="(-319.5+632)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_633_pos" x="0" y="(-319.5+633)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_634_pos" x="0" y="(-319.5+634)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_635_pos" x="0" y="(-319.5+635)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_636_pos" x="0" y="(-319.5+636)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_637_pos" x="0" y="(-319.5+637)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_638_pos" x="0" y="(-319.5+638)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_639_pos" x="0" y="(-319.5+639)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<!-- ABOVE IS FOR SSD -->
+	<!-- BELOW IS FOR ARICH -->
+
+	<quantity name="arich_shift" value="1862.82" unit="mm"/>
+	<quantity name="arich_thick" value="280.0" unit="mm"/>
+	<quantity name="arich_width" value="365.0" unit="mm"/>
+	<quantity name="arich_height" value="365.0" unit="mm"/>
+
+	<position name="arich_pos" x="0" y="0" z="arich_shift+0.5*arich_thick" />
+	<quantity name="aerogel_thick0" value="18.9" unit="mm"/>
+	<quantity name="aerogel_thick1" value="20.4" unit="mm"/>
+	<quantity name="aerogel_size" value="93.0" unit="mm"/>
+	<quantity name="aerogel_shift" value="43.0" unit="mm"/>
+	 
+	<position name="aerogel_pos0" x="0" y="0" z="aerogel_shift-0.5*arich_thick+0.5*aerogel_thick0" />
+	<position name="aerogel_pos1" x="0" y="0" z="aerogel_shift-0.5*arich_thick+aerogel_thick0+0.5*aerogel_thick1" />
+
+	<quantity name="mPMT_thick" value="16.4" unit="mm"/>
+	<quantity name="mPMT_size" value="49.3" unit="mm"/>
+	<quantity name="mPMT_gap" value="5.4" unit="mm"/>
+	<quantity name="manode_size" value="6.0" unit="mm"/>
+	<quantity name="mPMT_shift" value="103.0" unit="mm"/>
+
+	<position name="mPMT0_0_anode0_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode0_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode0_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode0_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode0_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode0_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode0_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode0_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode1_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode1_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode1_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode1_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode1_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode1_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode1_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode1_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode2_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode2_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode2_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode2_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode2_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode2_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode2_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode2_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode3_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode3_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode3_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode3_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode3_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode3_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode3_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode3_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode4_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode4_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode4_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode4_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode4_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode4_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode4_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode4_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode5_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode5_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode5_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode5_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode5_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode5_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode5_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode5_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode6_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode6_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode6_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode6_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode6_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode6_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode6_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode6_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode7_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode7_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode7_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode7_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode7_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode7_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode7_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode7_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode0_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode0_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode0_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode0_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode0_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode0_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode0_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode0_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode1_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode1_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode1_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode1_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode1_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode1_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode1_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode1_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode2_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode2_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode2_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode2_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode2_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode2_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode2_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode2_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode3_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode3_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode3_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode3_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode3_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode3_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode3_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode3_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode4_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode4_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode4_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode4_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode4_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode4_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode4_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode4_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode5_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode5_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode5_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode5_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode5_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode5_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode5_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode5_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode6_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode6_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode6_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode6_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode6_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode6_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode6_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode6_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode7_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode7_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode7_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode7_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode7_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode7_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode7_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode7_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode0_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode0_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode0_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode0_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode0_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode0_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode0_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode0_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode1_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode1_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode1_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode1_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode1_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode1_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode1_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode1_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode2_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode2_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode2_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode2_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode2_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode2_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode2_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode2_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode3_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode3_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode3_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode3_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode3_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode3_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode3_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode3_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode4_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode4_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode4_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode4_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode4_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode4_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode4_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode4_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode5_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode5_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode5_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode5_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode5_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode5_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode5_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode5_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode6_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode6_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode6_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode6_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode6_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode6_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode6_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode6_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode7_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode7_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode7_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode7_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode7_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode7_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode7_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode7_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode0_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode0_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode0_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode0_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode0_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode0_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode0_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode0_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode1_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode1_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode1_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode1_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode1_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode1_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode1_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode1_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode2_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode2_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode2_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode2_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode2_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode2_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode2_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode2_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode3_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode3_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode3_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode3_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode3_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode3_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode3_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode3_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode4_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode4_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode4_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode4_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode4_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode4_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode4_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode4_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode5_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode5_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode5_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode5_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode5_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode5_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode5_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode5_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode6_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode6_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode6_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode6_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode6_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode6_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode6_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode6_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode7_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode7_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode7_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode7_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode7_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode7_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode7_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode7_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode0_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode0_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode0_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode0_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode0_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode0_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode0_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode0_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode1_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode1_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode1_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode1_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode1_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode1_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode1_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode1_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode2_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode2_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode2_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode2_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode2_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode2_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode2_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode2_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode3_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode3_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode3_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode3_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode3_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode3_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode3_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode3_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode4_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode4_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode4_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode4_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode4_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode4_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode4_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode4_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode5_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode5_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode5_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode5_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode5_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode5_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode5_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode5_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode6_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode6_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode6_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode6_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode6_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode6_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode6_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode6_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode7_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode7_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode7_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode7_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode7_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode7_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode7_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode7_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode0_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode0_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode0_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode0_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode0_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode0_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode0_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode0_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode1_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode1_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode1_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode1_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode1_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode1_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode1_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode1_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode2_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode2_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode2_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode2_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode2_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode2_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode2_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode2_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode3_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode3_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode3_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode3_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode3_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode3_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode3_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode3_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode4_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode4_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode4_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode4_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode4_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode4_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode4_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode4_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode5_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode5_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode5_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode5_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode5_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode5_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode5_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode5_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode6_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode6_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode6_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode6_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode6_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode6_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode6_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode6_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode7_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode7_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode7_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode7_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode7_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode7_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode7_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode7_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode0_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode0_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode0_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode0_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode0_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode0_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode0_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode0_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode1_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode1_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode1_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode1_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode1_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode1_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode1_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode1_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode2_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode2_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode2_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode2_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode2_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode2_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode2_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode2_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode3_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode3_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode3_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode3_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode3_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode3_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode3_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode3_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode4_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode4_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode4_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode4_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode4_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode4_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode4_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode4_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode5_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode5_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode5_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode5_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode5_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode5_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode5_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode5_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode6_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode6_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode6_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode6_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode6_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode6_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode6_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode6_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode7_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode7_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode7_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode7_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode7_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode7_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode7_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode7_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode0_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode0_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode0_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode0_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode0_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode0_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode0_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode0_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode1_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode1_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode1_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode1_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode1_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode1_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode1_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode1_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode2_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode2_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode2_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode2_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode2_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode2_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode2_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode2_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode3_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode3_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode3_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode3_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode3_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode3_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode3_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode3_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode4_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode4_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode4_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode4_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode4_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode4_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode4_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode4_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode5_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode5_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode5_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode5_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode5_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode5_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode5_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode5_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode6_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode6_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode6_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode6_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode6_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode6_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode6_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode6_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode7_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode7_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode7_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode7_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode7_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode7_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode7_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode7_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode0_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode0_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode0_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode0_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode0_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode0_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode0_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode0_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode1_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode1_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode1_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode1_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode1_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode1_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode1_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode1_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode2_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode2_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode2_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode2_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode2_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode2_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode2_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode2_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode3_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode3_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode3_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode3_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode3_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode3_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode3_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode3_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode4_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode4_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode4_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode4_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode4_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode4_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode4_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode4_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode5_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode5_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode5_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode5_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode5_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode5_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode5_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode5_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode6_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode6_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode6_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode6_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode6_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode6_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode6_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode6_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode7_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode7_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode7_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode7_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode7_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode7_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode7_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode7_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+ 
+	<quantity name="PMTplate_thick" value="5.8" unit="mm"/>
+	<quantity name="PMTplate_size" value="195.7" unit="mm"/>
+
+	<position name="PMTplate_pos" x="0" y="0" z="mPMT_shift+mPMT_thick+0.5*PMTplate_thick" />
+	<!-- ABOVE IS FOR ARICH -->
+
+	 <!-- BELOW IS FOR RPC -->
+
+	 <quantity name="RPC_thick" value="54" unit="mm" />
+	 <quantity name="RPC_width" value="1066" unit="mm" />
+	 <quantity name="RPC_height" value="252" unit="mm" />
+	 <quantity name="RPC_volume_thick" value="200" unit="mm" />
+	 <quantity name="RPC0_shift" value="3953.38" unit="mm" />
+	 <quantity name="RPC1_shift" value="4050.39" unit="mm" />
+	 <quantity name="RPC_shift" value="4028.89" unit="mm" />
+
+	 <quantity name="RPC_Al_thick" value="1" unit="mm" />
+	 <quantity name="RPC_comb_thick" value="17" unit="mm" />
+	 <quantity name="RPC_PCB_thick" value="1" unit="mm" />
+	 <quantity name="RPC_acrylic_thick" value="1" unit="mm" />
+	 <quantity name="RPC_gas_width" value="960.5" unit="mm" />
+	 <quantity name="RPC_gas_height" value="250.5" unit="mm" />
+	 <quantity name="RPC_gas_thick" value="6" unit="mm" />
+
+	 <position name="RPC_pos" z="RPC_shift" unit="mm" />
+     <position name="RPC0_pos" z="RPC0_shift+0.5*RPC_thick-RPC_shift"/>
+     <position name="RPC0_Al0_pos" z="RPC_thick*(0-(2-1)*0.5)+RPC0_shift+0.5*RPC_thick-RPC_shift"/>
+     <position name="RPC0_Al1_pos" z="RPC_thick*(1-(2-1)*0.5)+RPC0_shift+0.5*RPC_thick-RPC_shift"/>
+     <position name="RPC1_pos" z="RPC1_shift+0.5*RPC_thick-RPC_shift"/>
+     <position name="RPC1_Al0_pos" z="RPC_thick*(0-(2-1)*0.5)+RPC1_shift+0.5*RPC_thick-RPC_shift"/>
+     <position name="RPC1_Al1_pos" z="RPC_thick*(1-(2-1)*0.5)+RPC1_shift+0.5*RPC_thick-RPC_shift"/>
+	 <!-- ABOVE IS FOR RPC -->
+
+	<!-- BELOW IS FOR LG -->
+
+    <quantity name="LG_length" value="340" unit="mm" />
+    <quantity name="LG_height" value="122" unit="mm" />
+    <quantity name="LG_width0" value="113" unit="mm" />
+    <quantity name="LG_width1" value="135" unit="mm" />
+    <quantity name="LG_width1T" value="145.4824" unit="mm" />
+    <quantity name="LG_angle" value="3.7074" unit="degree"/>
+    <quantity name="LG_TransHorOff_shift" value="2." unit="mm" />
+    <quantity name="LG_protrusion_thick" value="40" unit="mm" />
+    <quantity name="LG_PMTr" value="38" unit="mm" />
+    <quantity name="LG_PMTl" value="120" unit="mm" />
+
+    <position name="LG_trap_pos1" x="0" y="0" z="-0.5*(LG_TransHorOff_shift+LG_length+LG_protrusion_thick+LG_PMTl-LG_length)"/>
+	<position name="LG_protrusion_pos" x="0" y="0" z="LG_length-0.5*(LG_TransHorOff_shift+LG_length+LG_protrusion_thick+LG_PMTl)+0.5*LG_protrusion_thick"/>
+	<position name="LG_PMT_pos" x="0" y="0" z="LG_length-0.5*(LG_TransHorOff_shift+LG_length+LG_protrusion_thick+LG_PMTl)+LG_protrusion_thick+0.5*LG_PMTl"/>
+
+	<position name="LG_block00_pos" x="(0.5*(LG_width0+LG_width1T)+LG_TransHorOff_shift+Tolerance_space)" y="LG_height*(0-1)+2.5*(0-1)" z="0."/>
+	<position name="LG_block01_pos" x="0" y="LG_height*(0-1)+2.5*(0-1)" z="0"/>
+	<position name="LG_block02_pos" x="-(0.5*(LG_width0+LG_width1T)+LG_TransHorOff_shift+Tolerance_space)" y="LG_height*(0-1)+2.5*(0-1)" z="0."/>
+	<rotation name="LG_block00_rot" x="0" y="-1.0*LG_angle" z="0" />
+	<rotation name="LG_block01_rot" x="0" y="0" z="0" />
+	<rotation name="LG_block02_rot" x="0" y="LG_angle" z="0" />
+	<position name="LG_block10_pos" x="(0.5*(LG_width0+LG_width1T)+LG_TransHorOff_shift+Tolerance_space)" y="LG_height*(1-1)+2.5*(1-1)" z="0."/>
+	<position name="LG_block11_pos" x="0" y="LG_height*(1-1)+2.5*(1-1)" z="0"/>
+	<position name="LG_block12_pos" x="-(0.5*(LG_width0+LG_width1T)+LG_TransHorOff_shift+Tolerance_space)" y="LG_height*(1-1)+2.5*(1-1)" z="0."/>
+	<rotation name="LG_block10_rot" x="0" y="-1.0*LG_angle" z="0" />
+	<rotation name="LG_block11_rot" x="0" y="0" z="0" />
+	<rotation name="LG_block12_rot" x="0" y="LG_angle" z="0" />
+	<position name="LG_block20_pos" x="(0.5*(LG_width0+LG_width1T)+LG_TransHorOff_shift+Tolerance_space)" y="LG_height*(2-1)+2.5*(2-1)" z="0."/>
+	<position name="LG_block21_pos" x="0" y="LG_height*(2-1)+2.5*(2-1)" z="0"/>
+	<position name="LG_block22_pos" x="-(0.5*(LG_width0+LG_width1T)+LG_TransHorOff_shift+Tolerance_space)" y="LG_height*(2-1)+2.5*(2-1)" z="0."/>
+	<rotation name="LG_block20_rot" x="0" y="-1.0*LG_angle" z="0" />
+	<rotation name="LG_block21_rot" x="0" y="0" z="0" />
+	<rotation name="LG_block22_rot" x="0" y="LG_angle" z="0" />
+	<quantity name="calor_length" value="520" unit="mm" />
+	<quantity name="calor_height" value="380" unit="mm" />
+	<quantity name="calor_width" value="900" unit="mm" />
+    <quantity name="calor_shift" value="4286.4" unit="mm" />
+    <position name="calor_pos" x="0" y="0" z="calor_shift+calor_length*0.5"/>
+
+	 <!-- ABOVE IS FOR LG -->
+
+  
 
 	<!-- ********** Refractive index ********** -->
 

--- a/ConstBase/Geometry/phase1c_Graphite_nomag.gdml
+++ b/ConstBase/Geometry/phase1c_Graphite_nomag.gdml
@@ -8,6 +8,2145 @@
 --> 
 
 <define>
+	
+	<constant name="DEG2RAD" value="pi/180." />
+	<quantity name="world_size" value="10000." unit="mm"/>
+	<quantity name="Tolerance_space" value="1." unit="mm" />
+	<position name="center" x="0" y="0" z="0" unit="mm"/>
+	
+    <!-- BELOW IS FOR T0 -->
+		
+	<quantity name="T0_length" value="280.0" unit="mm"/>
+	<quantity name="T0_width" value="210.0" unit="mm"/>
+	<quantity name="T0_height" value="300.0" unit="mm"/>
+	<quantity name="T0_shift" value="-267.5" unit="mm"/>
+	<quantity name="T0_acrylic_shift" value="40.0" unit="mm"/>
+	<position name="T0_pos" z="T0_shift+T0_acrylic_shift"/>
+
+	<quantity name="T0_acrylic_length" value="150.0" unit="mm"/>
+	<quantity name="T0_acrylic_width" value="3.0" unit="mm"/>
+	<quantity name="T0_acrylic_height" value="3.0" unit="mm"/>
+		
+	<position name="T0_acrylic0_pos" x="T0_acrylic_width*(0-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*0"/>
+	<position name="T0_acrylic1_pos" x="T0_acrylic_width*(1-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*1"/>
+	<position name="T0_acrylic2_pos" x="T0_acrylic_width*(2-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*0"/>
+	<position name="T0_acrylic3_pos" x="T0_acrylic_width*(3-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*1"/>
+	<position name="T0_acrylic4_pos" x="T0_acrylic_width*(4-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*0"/>
+	<position name="T0_acrylic5_pos" x="T0_acrylic_width*(5-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*1"/>
+	<position name="T0_acrylic6_pos" x="T0_acrylic_width*(6-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*0"/>
+	<position name="T0_acrylic7_pos" x="T0_acrylic_width*(7-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*1"/>
+	<position name="T0_acrylic8_pos" x="T0_acrylic_width*(8-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*0"/>
+	<position name="T0_acrylic9_pos" x="T0_acrylic_width*(9-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*1"/>
+	<position name="T0_acrylic10_pos" x="T0_acrylic_width*(10-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*0"/>
+	<position name="T0_acrylic11_pos" x="T0_acrylic_width*(11-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*1"/>
+	<position name="T0_acrylic12_pos" x="T0_acrylic_width*(12-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*0"/>
+	<position name="T0_acrylic13_pos" x="T0_acrylic_width*(13-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*1"/>
+	<position name="T0_acrylic14_pos" x="T0_acrylic_width*(14-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*0"/>
+	<position name="T0_acrylic15_pos" x="T0_acrylic_width*(15-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*1"/>
+	<position name="T0_acrylic16_pos" x="T0_acrylic_width*(16-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*0"/>
+	<position name="T0_acrylic17_pos" x="T0_acrylic_width*(17-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*1"/>
+	<position name="T0_acrylic18_pos" x="T0_acrylic_width*(18-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*0"/>
+	<position name="T0_acrylic19_pos" x="T0_acrylic_width*(19-(20-1)*0.5)" z="-T0_acrylic_shift+T0_acrylic_width*1"/>
+	    
+    <rotation name="T0_union1_rot" x="90" unit="deg"/>
+	<rotation name="T0_acrylic_rot" x="-45" unit="deg"/>
+
+	<!-- ABOVE IS FOR T0 -->
+	<!-- BELOW IS FOR TARGET -->
+	    
+	    <quantity name="target_width" value="100.0" unit="mm"/>
+	    <quantity name="target_height" value="50.0" unit="mm"/>
+	    <quantity name="target_depth" value="20" unit="mm"/>
+	    
+	    <position name="target_pos" x="0" y="0" z="380.5"/>
+
+	 <!-- ABOVE IS FOR TARGET -->
+
+  <!-- BELOW IS FOR SSD -->
+
+	<quantity name="ssdD0_thick" value=".300" unit="mm"/>
+	<quantity name="ssdD0_height" value="38.46" unit="mm"/>
+	<quantity name="ssdD0_width" value="98.33" unit="mm"/>
+	
+	<quantity name="ssdD0_chanwidth" value="0.059999" unit="mm"/>
+	<quantity name="ssdD0_changap" value="0.000001" unit="mm"/>
+	
+	<quantity name="ssdD0_overlap" value="2.0" unit="mm"/>
+	<quantity name="ssd_bkpln_thick" value=".300" unit="mm"/>
+	
+	<quantity name="ssdStation0_shift" value="0" unit="mm"/>
+	<quantity name="ssdStation1_shift" value="281" unit="mm"/>
+	<quantity name="ssdStation2_shift" value="501" unit="mm"/>
+	<quantity name="ssdStation3_shift" value="615" unit="mm"/>
+	<quantity name="ssdStation4_shift" value="846" unit="mm"/>
+	<quantity name="ssdStation5_shift" value="1146.38" unit="mm"/>
+	<quantity name="ssdStation6_shift" value="1471.82" unit="mm"/>
+	<quantity name="ssdStation7_shift" value="1744.82" unit="mm"/>
+	
+	<quantity name="mount_thick" value="6.35" unit="mm" />
+	<quantity name="mount_width" value="115.98" unit="mm" />
+	<quantity name="mount_hole" value="80.00" unit="mm" />
+	<quantity name="mount_enclosure_size" value="200" unit="mm" />
+
+	<quantity name="Mylar_Window_thick" value="0.500" unit="mm" />
+	<quantity name="Mylar_shift" value="20" unit="mm"/>
+	    
+	<quantity name="ssdStationsingleLength" value="50" unit="mm" />
+	<quantity name="ssdStationsingleWidth" value="300" unit="mm" />
+	<quantity name="ssdStationsingleHeight" value="300" unit="mm" />
+	<position name="ssdStation0_pos" x="0" y="0" z="ssdStation0_shift+ssdD0_thick-0.5*mount_thick"/>
+
+	<position name="ssdsensor_0_0_0_pos" x="0" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_0_0_0_pos" x="0" y="0" z="0*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_0_0_0_rot" x="180.0*0" y="0" z="0" unit="deg"/>
+	<position name="ssdsensor_0_1_0_pos" x="0" y="0" z="(1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_0_1_0_pos" x="0" y="0" z="1*ssdD0_thick+(1-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_0_1_0_rot" x="180.0*1" y="0" z="90" unit="deg"/>
+	<position name="ssdStation1_pos" x="0" y="0" z="ssdStation1_shift+ssdD0_thick-0.5*mount_thick"/>
+
+	<position name="ssdsensor_1_0_0_pos" x="0" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_1_0_0_pos" x="0" y="0" z="0*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_1_0_0_rot" x="180.0*0" y="0" z="0" unit="deg"/>
+	<position name="ssdsensor_1_1_0_pos" x="0" y="0" z="(1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_1_1_0_pos" x="0" y="0" z="1*ssdD0_thick+(1-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_1_1_0_rot" x="180.0*1" y="0" z="90" unit="deg"/>
+	<position name="ssdStation2_pos" x="0" y="0" z="ssdStation2_shift+ssdD0_thick-0.5*mount_thick"/>
+
+	<position name="ssdsensor_2_0_0_pos" x="0" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_2_0_0_pos" x="0" y="0" z="0*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_2_0_0_rot" x="180.0*0" y="0" z="315" unit="deg"/>
+	<position name="ssdsensor_2_1_0_pos" x="0" y="0" z="(1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_2_1_0_pos" x="0" y="0" z="1*ssdD0_thick+(1-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_2_1_0_rot" x="180.0*0" y="0" z="0" unit="deg"/>
+	<position name="ssdsensor_2_2_0_pos" x="0" y="0" z="0.5*ssdD0_thick+ssd_bkpln_thick+0.5*mount_thick+0"/>
+	<position name="ssd_bkpln_2_2_0_pos" x="0" y="0" z="0.5*ssd_bkpln_thick+0.5*mount_thick+0"/>
+	<rotation name="ssdsensor_2_2_0_rot" x="180.0*1" y="0" z="90" unit="deg"/>
+	<position name="ssdStation3_pos" x="0" y="0" z="ssdStation3_shift+ssdD0_thick-0.5*mount_thick"/>
+
+	<position name="ssdsensor_3_0_0_pos" x="0" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_3_0_0_pos" x="0" y="0" z="0*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_3_0_0_rot" x="180.0*0" y="0" z="315" unit="deg"/>
+	<position name="ssdsensor_3_1_0_pos" x="0" y="0" z="(1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_3_1_0_pos" x="0" y="0" z="1*ssdD0_thick+(1-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_3_1_0_rot" x="180.0*0" y="0" z="0" unit="deg"/>
+	<position name="ssdsensor_3_2_0_pos" x="0" y="0" z="0.5*ssdD0_thick+ssd_bkpln_thick+0.5*mount_thick+0"/>
+	<position name="ssd_bkpln_3_2_0_pos" x="0" y="0" z="0.5*ssd_bkpln_thick+0.5*mount_thick+0"/>
+	<rotation name="ssdsensor_3_2_0_rot" x="180.0*1" y="0" z="90" unit="deg"/>
+	<position name="ssdStation4_pos" x="0" y="0" z="ssdStation4_shift+ssdD0_thick-0.5*mount_thick"/>
+
+	<position name="ssdsensor_4_0_0_pos" x="0" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_4_0_0_pos" x="0" y="0" z="0*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_4_0_0_rot" x="180.0*0" y="0" z="0" unit="deg"/>
+	<position name="ssdsensor_4_1_0_pos" x="0" y="0" z="(1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_4_1_0_pos" x="0" y="0" z="1*ssdD0_thick+(1-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_4_1_0_rot" x="180.0*1" y="0" z="90" unit="deg"/>
+	<position name="ssdStation5_pos" x="0" y="0" z="ssdStation5_shift+ssdD0_thick-0.5*mount_thick"/>
+
+	<position name="ssdsensor_5_0_0_pos" x="-18.23" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_5_0_0_pos" x="-18.23" y="0" z="0*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_5_0_0_rot" x="180.0*0" y="0" z="270" unit="deg"/>
+	<position name="ssdsensor_5_0_1_pos" x="18.23" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_5_0_1_pos" x="18.23" y="0" z="0*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_5_0_1_rot" x="180.0*0" y="0" z="90" unit="deg"/>
+	<position name="ssdsensor_5_1_0_pos" x="0" y="-18.23" z="(1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_5_1_0_pos" x="0" y="-18.23" z="1*ssdD0_thick+(1-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_5_1_0_rot" x="180.0*1" y="0" z="0" unit="deg"/>
+	<position name="ssdsensor_5_1_1_pos" x="0" y="18.23" z="(1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_5_1_1_pos" x="0" y="18.23" z="1*ssdD0_thick+(1-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_5_1_1_rot" x="180.0*1" y="0" z="180" unit="deg"/>
+	<position name="ssdsensor_5_2_0_pos" x="12.92" y="-12.92" z="0.5*ssdD0_thick+ssd_bkpln_thick+0.5*mount_thick+0"/>
+	<position name="ssd_bkpln_5_2_0_pos" x="12.92" y="-12.92" z="0.5*ssd_bkpln_thick+0.5*mount_thick+0"/>
+	<rotation name="ssdsensor_5_2_0_rot" x="180.0*1" y="0" z="45" unit="deg"/>
+	<position name="ssdsensor_5_2_1_pos" x="-12.92" y="12.92" z="0.5*ssdD0_thick+ssd_bkpln_thick+0.5*mount_thick+0"/>
+	<position name="ssd_bkpln_5_2_1_pos" x="-12.92" y="12.92" z="0.5*ssd_bkpln_thick+0.5*mount_thick+0"/>
+	<rotation name="ssdsensor_5_2_1_rot" x="180.0*1" y="0" z="225" unit="deg"/>
+	<position name="ssdStation6_pos" x="0" y="0" z="ssdStation6_shift+ssdD0_thick-0.5*mount_thick"/>
+
+	<position name="ssdsensor_6_0_0_pos" x="-18.23" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_6_0_0_pos" x="-18.23" y="0" z="0*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_6_0_0_rot" x="180.0*0" y="0" z="270" unit="deg"/>
+	<position name="ssdsensor_6_0_1_pos" x="18.23" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_6_0_1_pos" x="18.23" y="0" z="0*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_6_0_1_rot" x="180.0*0" y="0" z="90" unit="deg"/>
+	<position name="ssdsensor_6_1_0_pos" x="0" y="-18.23" z="(1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_6_1_0_pos" x="0" y="-18.23" z="1*ssdD0_thick+(1-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_6_1_0_rot" x="180.0*1" y="0" z="0" unit="deg"/>
+	<position name="ssdsensor_6_1_1_pos" x="0" y="18.23" z="(1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_6_1_1_pos" x="0" y="18.23" z="1*ssdD0_thick+(1-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_6_1_1_rot" x="180.0*1" y="0" z="180" unit="deg"/>
+	<position name="ssdsensor_6_2_0_pos" x="12.92" y="-12.92" z="0.5*ssdD0_thick+ssd_bkpln_thick+0.5*mount_thick+0"/>
+	<position name="ssd_bkpln_6_2_0_pos" x="12.92" y="-12.92" z="0.5*ssd_bkpln_thick+0.5*mount_thick+0"/>
+	<rotation name="ssdsensor_6_2_0_rot" x="180.0*1" y="0" z="45" unit="deg"/>
+	<position name="ssdsensor_6_2_1_pos" x="-12.92" y="12.92" z="0.5*ssdD0_thick+ssd_bkpln_thick+0.5*mount_thick+0"/>
+	<position name="ssd_bkpln_6_2_1_pos" x="-12.92" y="12.92" z="0.5*ssd_bkpln_thick+0.5*mount_thick+0"/>
+	<rotation name="ssdsensor_6_2_1_rot" x="180.0*1" y="0" z="225" unit="deg"/>
+	<position name="ssdStation7_pos" x="0" y="0" z="ssdStation7_shift+ssdD0_thick-0.5*mount_thick"/>
+
+	<position name="ssdsensor_7_0_0_pos" x="-18.23" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_7_0_0_pos" x="-18.23" y="0" z="0*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_7_0_0_rot" x="180.0*0" y="0" z="270" unit="deg"/>
+	<position name="ssdsensor_7_0_1_pos" x="18.23" y="0" z="(0-0.5)*ssdD0_thick+(0-0.5)*mount_thick+(0-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_7_0_1_pos" x="18.23" y="0" z="0*ssdD0_thick+(0-0.5)*mount_thick+(0-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_7_0_1_rot" x="180.0*0" y="0" z="90" unit="deg"/>
+	<position name="ssdsensor_7_1_0_pos" x="0" y="-18.23" z="(1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_7_1_0_pos" x="0" y="-18.23" z="1*ssdD0_thick+(1-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_7_1_0_rot" x="180.0*1" y="0" z="0" unit="deg"/>
+	<position name="ssdsensor_7_1_1_pos" x="0" y="19.23" z="(1-0.5)*ssdD0_thick+(1-0.5)*mount_thick+(1-1)*ssd_bkpln_thick+0"/>
+	<position name="ssd_bkpln_7_1_1_pos" x="0" y="19.23" z="1*ssdD0_thick+(1-0.5)*mount_thick+(1-0.5)*ssd_bkpln_thick+0"/>
+	<rotation name="ssdsensor_7_1_1_rot" x="180.0*1" y="0" z="180" unit="deg"/>
+	<position name="ssdmount_local_0_0_pos" x="0" y="0" z="0"/>
+	<position name="ssdmount_0_0_pos" x="0" y="0" z="0+0.5*mount_thick"/>
+	<rotation name="ssdmount_0_0_rot" x="-0.44" y="-2.02" unit="deg"/>
+	<position name="ssdmount_local_1_0_pos" x="0" y="0" z="0"/>
+	<position name="ssdmount_1_0_pos" x="0" y="0" z="0+0.5*mount_thick"/>
+	<rotation name="ssdmount_1_0_rot" x="0.24" y="-1.26" unit="deg"/>
+	<position name="ssdmount_local_2_0_pos" x="0" y="0" z="0"/>
+	<position name="ssdmount_2_0_pos" x="0" y="0" z="0+0.5*mount_thick"/>
+	<rotation name="ssdmount_2_0_rot" x="0" y="0" unit="deg"/>
+	<position name="ssdmount_local_2_1_pos" x="0" y="0" z="0"/>
+	<position name="ssdmount_2_1_pos" x="0" y="0" z="10+0.5*mount_thick"/>
+	<rotation name="ssdmount_2_1_rot" x="0" y="0" unit="deg"/>
+	<position name="ssdmount_local_3_0_pos" x="0" y="0" z="0"/>
+	<position name="ssdmount_3_0_pos" x="0" y="0" z="0+0.5*mount_thick"/>
+	<rotation name="ssdmount_3_0_rot" x="0" y="0" unit="deg"/>
+	<position name="ssdmount_local_3_1_pos" x="0" y="0" z="0"/>
+	<position name="ssdmount_3_1_pos" x="0" y="0" z="10+0.5*mount_thick"/>
+	<rotation name="ssdmount_3_1_rot" x="0" y="0" unit="deg"/>
+	<position name="ssdmount_local_4_0_pos" x="0" y="0" z="0"/>
+	<position name="ssdmount_4_0_pos" x="0" y="0" z="0+0.5*mount_thick"/>
+	<rotation name="ssdmount_4_0_rot" x="0" y="0" unit="deg"/>
+	<position name="ssdmount_local_5_0_pos" x="0" y="0" z="0"/>
+	<position name="ssdmount_5_0_pos" x="0" y="0" z="0+0.5*mount_thick"/>
+	<rotation name="ssdmount_5_0_rot" x="0" y="0" unit="deg"/>
+	<position name="ssdmount_local_5_1_pos" x="0" y="0" z="0"/>
+	<position name="ssdmount_5_1_pos" x="0" y="0" z="10+0.5*mount_thick"/>
+	<rotation name="ssdmount_5_1_rot" x="0" y="0" unit="deg"/>
+	<position name="ssdmount_local_6_0_pos" x="0" y="0" z="0"/>
+	<position name="ssdmount_6_0_pos" x="0" y="0" z="0+0.5*mount_thick"/>
+	<rotation name="ssdmount_6_0_rot" x="-0.06" y="-1.49" unit="deg"/>
+	<position name="ssdmount_local_6_1_pos" x="0" y="0" z="0"/>
+	<position name="ssdmount_6_1_pos" x="0" y="0" z="10+0.5*mount_thick"/>
+	<rotation name="ssdmount_6_1_rot" x="-0.06" y="-1.49" unit="deg"/>
+	<position name="ssdmount_local_7_0_pos" x="0" y="0" z="0"/>
+	<position name="ssdmount_7_0_pos" x="0" y="0" z="0+0.5*mount_thick"/>
+	<rotation name="ssdmount_7_0_rot" x="0.36" y="0.31" unit="deg"/>
+
+	<position name="ssd_USMylarWindow_pos" x="0" y="0" z="-1*Mylar_shift"/>
+	<position name="ssd_DSMylarWindow_pos" x="0" y="0" z="Mylar_shift"/>
+
+	<position name="ssd_mount_u1_pos" x="70" y="0" z="0"/>
+	<rotation name="ssd_mount_u1_rot" y="-90" unit="deg"/>
+	<position name="ssd_mount_u2_pos" x="0" y="-70" z="0"/>
+	<rotation name="ssd_mount_u2_rot" y="-90" z="-90" unit="deg"/>
+	<rotation name="ssd_mount_u3_rot" z="90" unit="deg"/>
+	<position name="ssd_mount_u4_pos" x="80.1" y="-80.4"/>
+	<rotation name="ssd_mount_u4_rot" y="-90" z="135" unit="deg"/>
+	<position name="ssd_mount_out_pos1" z="0.5*mount_thick" unit="mm" />
+	<position name="ssd_mount_out_pos2" z="-0.5*mount_thick" unit="mm" />
+
+    <quantity name="ssdStationrotateLength" value="50" unit="mm" />
+	<quantity name="ssdStationrotateWidth" value="300" unit="mm" />
+	<quantity name="ssdStationrotateHeight" value="300" unit="mm" />
+	<quantity name="ssdStationdouble3plLength" value="100" unit="mm" />
+	<quantity name="ssdStationdouble3plWidth" value="450" unit="mm" />
+	<quantity name="ssdStationdouble3plHeight" value="450" unit="mm" />
+	<quantity name="ssdStationdouble2plLength" value="100" unit="mm" />
+	<quantity name="ssdStationdouble2plWidth" value="300" unit="mm" />
+	<quantity name="ssdStationdouble2plHeight" value="300" unit="mm" />
+
+	<position name="ssd_chan_0_pos" x="0" y="(-319.5+0)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_1_pos" x="0" y="(-319.5+1)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_2_pos" x="0" y="(-319.5+2)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_3_pos" x="0" y="(-319.5+3)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_4_pos" x="0" y="(-319.5+4)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_5_pos" x="0" y="(-319.5+5)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_6_pos" x="0" y="(-319.5+6)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_7_pos" x="0" y="(-319.5+7)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_8_pos" x="0" y="(-319.5+8)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_9_pos" x="0" y="(-319.5+9)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_10_pos" x="0" y="(-319.5+10)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_11_pos" x="0" y="(-319.5+11)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_12_pos" x="0" y="(-319.5+12)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_13_pos" x="0" y="(-319.5+13)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_14_pos" x="0" y="(-319.5+14)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_15_pos" x="0" y="(-319.5+15)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_16_pos" x="0" y="(-319.5+16)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_17_pos" x="0" y="(-319.5+17)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_18_pos" x="0" y="(-319.5+18)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_19_pos" x="0" y="(-319.5+19)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_20_pos" x="0" y="(-319.5+20)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_21_pos" x="0" y="(-319.5+21)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_22_pos" x="0" y="(-319.5+22)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_23_pos" x="0" y="(-319.5+23)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_24_pos" x="0" y="(-319.5+24)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_25_pos" x="0" y="(-319.5+25)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_26_pos" x="0" y="(-319.5+26)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_27_pos" x="0" y="(-319.5+27)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_28_pos" x="0" y="(-319.5+28)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_29_pos" x="0" y="(-319.5+29)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_30_pos" x="0" y="(-319.5+30)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_31_pos" x="0" y="(-319.5+31)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_32_pos" x="0" y="(-319.5+32)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_33_pos" x="0" y="(-319.5+33)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_34_pos" x="0" y="(-319.5+34)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_35_pos" x="0" y="(-319.5+35)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_36_pos" x="0" y="(-319.5+36)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_37_pos" x="0" y="(-319.5+37)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_38_pos" x="0" y="(-319.5+38)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_39_pos" x="0" y="(-319.5+39)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_40_pos" x="0" y="(-319.5+40)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_41_pos" x="0" y="(-319.5+41)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_42_pos" x="0" y="(-319.5+42)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_43_pos" x="0" y="(-319.5+43)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_44_pos" x="0" y="(-319.5+44)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_45_pos" x="0" y="(-319.5+45)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_46_pos" x="0" y="(-319.5+46)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_47_pos" x="0" y="(-319.5+47)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_48_pos" x="0" y="(-319.5+48)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_49_pos" x="0" y="(-319.5+49)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_50_pos" x="0" y="(-319.5+50)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_51_pos" x="0" y="(-319.5+51)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_52_pos" x="0" y="(-319.5+52)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_53_pos" x="0" y="(-319.5+53)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_54_pos" x="0" y="(-319.5+54)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_55_pos" x="0" y="(-319.5+55)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_56_pos" x="0" y="(-319.5+56)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_57_pos" x="0" y="(-319.5+57)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_58_pos" x="0" y="(-319.5+58)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_59_pos" x="0" y="(-319.5+59)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_60_pos" x="0" y="(-319.5+60)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_61_pos" x="0" y="(-319.5+61)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_62_pos" x="0" y="(-319.5+62)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_63_pos" x="0" y="(-319.5+63)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_64_pos" x="0" y="(-319.5+64)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_65_pos" x="0" y="(-319.5+65)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_66_pos" x="0" y="(-319.5+66)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_67_pos" x="0" y="(-319.5+67)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_68_pos" x="0" y="(-319.5+68)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_69_pos" x="0" y="(-319.5+69)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_70_pos" x="0" y="(-319.5+70)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_71_pos" x="0" y="(-319.5+71)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_72_pos" x="0" y="(-319.5+72)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_73_pos" x="0" y="(-319.5+73)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_74_pos" x="0" y="(-319.5+74)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_75_pos" x="0" y="(-319.5+75)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_76_pos" x="0" y="(-319.5+76)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_77_pos" x="0" y="(-319.5+77)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_78_pos" x="0" y="(-319.5+78)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_79_pos" x="0" y="(-319.5+79)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_80_pos" x="0" y="(-319.5+80)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_81_pos" x="0" y="(-319.5+81)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_82_pos" x="0" y="(-319.5+82)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_83_pos" x="0" y="(-319.5+83)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_84_pos" x="0" y="(-319.5+84)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_85_pos" x="0" y="(-319.5+85)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_86_pos" x="0" y="(-319.5+86)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_87_pos" x="0" y="(-319.5+87)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_88_pos" x="0" y="(-319.5+88)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_89_pos" x="0" y="(-319.5+89)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_90_pos" x="0" y="(-319.5+90)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_91_pos" x="0" y="(-319.5+91)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_92_pos" x="0" y="(-319.5+92)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_93_pos" x="0" y="(-319.5+93)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_94_pos" x="0" y="(-319.5+94)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_95_pos" x="0" y="(-319.5+95)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_96_pos" x="0" y="(-319.5+96)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_97_pos" x="0" y="(-319.5+97)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_98_pos" x="0" y="(-319.5+98)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_99_pos" x="0" y="(-319.5+99)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_100_pos" x="0" y="(-319.5+100)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_101_pos" x="0" y="(-319.5+101)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_102_pos" x="0" y="(-319.5+102)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_103_pos" x="0" y="(-319.5+103)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_104_pos" x="0" y="(-319.5+104)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_105_pos" x="0" y="(-319.5+105)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_106_pos" x="0" y="(-319.5+106)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_107_pos" x="0" y="(-319.5+107)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_108_pos" x="0" y="(-319.5+108)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_109_pos" x="0" y="(-319.5+109)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_110_pos" x="0" y="(-319.5+110)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_111_pos" x="0" y="(-319.5+111)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_112_pos" x="0" y="(-319.5+112)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_113_pos" x="0" y="(-319.5+113)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_114_pos" x="0" y="(-319.5+114)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_115_pos" x="0" y="(-319.5+115)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_116_pos" x="0" y="(-319.5+116)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_117_pos" x="0" y="(-319.5+117)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_118_pos" x="0" y="(-319.5+118)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_119_pos" x="0" y="(-319.5+119)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_120_pos" x="0" y="(-319.5+120)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_121_pos" x="0" y="(-319.5+121)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_122_pos" x="0" y="(-319.5+122)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_123_pos" x="0" y="(-319.5+123)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_124_pos" x="0" y="(-319.5+124)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_125_pos" x="0" y="(-319.5+125)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_126_pos" x="0" y="(-319.5+126)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_127_pos" x="0" y="(-319.5+127)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_128_pos" x="0" y="(-319.5+128)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_129_pos" x="0" y="(-319.5+129)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_130_pos" x="0" y="(-319.5+130)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_131_pos" x="0" y="(-319.5+131)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_132_pos" x="0" y="(-319.5+132)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_133_pos" x="0" y="(-319.5+133)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_134_pos" x="0" y="(-319.5+134)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_135_pos" x="0" y="(-319.5+135)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_136_pos" x="0" y="(-319.5+136)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_137_pos" x="0" y="(-319.5+137)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_138_pos" x="0" y="(-319.5+138)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_139_pos" x="0" y="(-319.5+139)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_140_pos" x="0" y="(-319.5+140)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_141_pos" x="0" y="(-319.5+141)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_142_pos" x="0" y="(-319.5+142)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_143_pos" x="0" y="(-319.5+143)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_144_pos" x="0" y="(-319.5+144)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_145_pos" x="0" y="(-319.5+145)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_146_pos" x="0" y="(-319.5+146)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_147_pos" x="0" y="(-319.5+147)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_148_pos" x="0" y="(-319.5+148)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_149_pos" x="0" y="(-319.5+149)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_150_pos" x="0" y="(-319.5+150)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_151_pos" x="0" y="(-319.5+151)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_152_pos" x="0" y="(-319.5+152)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_153_pos" x="0" y="(-319.5+153)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_154_pos" x="0" y="(-319.5+154)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_155_pos" x="0" y="(-319.5+155)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_156_pos" x="0" y="(-319.5+156)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_157_pos" x="0" y="(-319.5+157)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_158_pos" x="0" y="(-319.5+158)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_159_pos" x="0" y="(-319.5+159)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_160_pos" x="0" y="(-319.5+160)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_161_pos" x="0" y="(-319.5+161)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_162_pos" x="0" y="(-319.5+162)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_163_pos" x="0" y="(-319.5+163)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_164_pos" x="0" y="(-319.5+164)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_165_pos" x="0" y="(-319.5+165)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_166_pos" x="0" y="(-319.5+166)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_167_pos" x="0" y="(-319.5+167)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_168_pos" x="0" y="(-319.5+168)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_169_pos" x="0" y="(-319.5+169)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_170_pos" x="0" y="(-319.5+170)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_171_pos" x="0" y="(-319.5+171)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_172_pos" x="0" y="(-319.5+172)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_173_pos" x="0" y="(-319.5+173)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_174_pos" x="0" y="(-319.5+174)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_175_pos" x="0" y="(-319.5+175)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_176_pos" x="0" y="(-319.5+176)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_177_pos" x="0" y="(-319.5+177)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_178_pos" x="0" y="(-319.5+178)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_179_pos" x="0" y="(-319.5+179)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_180_pos" x="0" y="(-319.5+180)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_181_pos" x="0" y="(-319.5+181)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_182_pos" x="0" y="(-319.5+182)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_183_pos" x="0" y="(-319.5+183)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_184_pos" x="0" y="(-319.5+184)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_185_pos" x="0" y="(-319.5+185)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_186_pos" x="0" y="(-319.5+186)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_187_pos" x="0" y="(-319.5+187)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_188_pos" x="0" y="(-319.5+188)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_189_pos" x="0" y="(-319.5+189)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_190_pos" x="0" y="(-319.5+190)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_191_pos" x="0" y="(-319.5+191)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_192_pos" x="0" y="(-319.5+192)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_193_pos" x="0" y="(-319.5+193)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_194_pos" x="0" y="(-319.5+194)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_195_pos" x="0" y="(-319.5+195)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_196_pos" x="0" y="(-319.5+196)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_197_pos" x="0" y="(-319.5+197)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_198_pos" x="0" y="(-319.5+198)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_199_pos" x="0" y="(-319.5+199)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_200_pos" x="0" y="(-319.5+200)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_201_pos" x="0" y="(-319.5+201)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_202_pos" x="0" y="(-319.5+202)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_203_pos" x="0" y="(-319.5+203)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_204_pos" x="0" y="(-319.5+204)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_205_pos" x="0" y="(-319.5+205)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_206_pos" x="0" y="(-319.5+206)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_207_pos" x="0" y="(-319.5+207)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_208_pos" x="0" y="(-319.5+208)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_209_pos" x="0" y="(-319.5+209)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_210_pos" x="0" y="(-319.5+210)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_211_pos" x="0" y="(-319.5+211)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_212_pos" x="0" y="(-319.5+212)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_213_pos" x="0" y="(-319.5+213)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_214_pos" x="0" y="(-319.5+214)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_215_pos" x="0" y="(-319.5+215)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_216_pos" x="0" y="(-319.5+216)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_217_pos" x="0" y="(-319.5+217)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_218_pos" x="0" y="(-319.5+218)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_219_pos" x="0" y="(-319.5+219)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_220_pos" x="0" y="(-319.5+220)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_221_pos" x="0" y="(-319.5+221)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_222_pos" x="0" y="(-319.5+222)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_223_pos" x="0" y="(-319.5+223)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_224_pos" x="0" y="(-319.5+224)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_225_pos" x="0" y="(-319.5+225)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_226_pos" x="0" y="(-319.5+226)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_227_pos" x="0" y="(-319.5+227)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_228_pos" x="0" y="(-319.5+228)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_229_pos" x="0" y="(-319.5+229)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_230_pos" x="0" y="(-319.5+230)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_231_pos" x="0" y="(-319.5+231)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_232_pos" x="0" y="(-319.5+232)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_233_pos" x="0" y="(-319.5+233)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_234_pos" x="0" y="(-319.5+234)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_235_pos" x="0" y="(-319.5+235)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_236_pos" x="0" y="(-319.5+236)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_237_pos" x="0" y="(-319.5+237)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_238_pos" x="0" y="(-319.5+238)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_239_pos" x="0" y="(-319.5+239)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_240_pos" x="0" y="(-319.5+240)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_241_pos" x="0" y="(-319.5+241)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_242_pos" x="0" y="(-319.5+242)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_243_pos" x="0" y="(-319.5+243)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_244_pos" x="0" y="(-319.5+244)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_245_pos" x="0" y="(-319.5+245)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_246_pos" x="0" y="(-319.5+246)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_247_pos" x="0" y="(-319.5+247)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_248_pos" x="0" y="(-319.5+248)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_249_pos" x="0" y="(-319.5+249)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_250_pos" x="0" y="(-319.5+250)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_251_pos" x="0" y="(-319.5+251)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_252_pos" x="0" y="(-319.5+252)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_253_pos" x="0" y="(-319.5+253)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_254_pos" x="0" y="(-319.5+254)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_255_pos" x="0" y="(-319.5+255)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_256_pos" x="0" y="(-319.5+256)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_257_pos" x="0" y="(-319.5+257)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_258_pos" x="0" y="(-319.5+258)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_259_pos" x="0" y="(-319.5+259)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_260_pos" x="0" y="(-319.5+260)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_261_pos" x="0" y="(-319.5+261)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_262_pos" x="0" y="(-319.5+262)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_263_pos" x="0" y="(-319.5+263)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_264_pos" x="0" y="(-319.5+264)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_265_pos" x="0" y="(-319.5+265)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_266_pos" x="0" y="(-319.5+266)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_267_pos" x="0" y="(-319.5+267)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_268_pos" x="0" y="(-319.5+268)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_269_pos" x="0" y="(-319.5+269)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_270_pos" x="0" y="(-319.5+270)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_271_pos" x="0" y="(-319.5+271)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_272_pos" x="0" y="(-319.5+272)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_273_pos" x="0" y="(-319.5+273)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_274_pos" x="0" y="(-319.5+274)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_275_pos" x="0" y="(-319.5+275)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_276_pos" x="0" y="(-319.5+276)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_277_pos" x="0" y="(-319.5+277)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_278_pos" x="0" y="(-319.5+278)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_279_pos" x="0" y="(-319.5+279)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_280_pos" x="0" y="(-319.5+280)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_281_pos" x="0" y="(-319.5+281)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_282_pos" x="0" y="(-319.5+282)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_283_pos" x="0" y="(-319.5+283)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_284_pos" x="0" y="(-319.5+284)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_285_pos" x="0" y="(-319.5+285)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_286_pos" x="0" y="(-319.5+286)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_287_pos" x="0" y="(-319.5+287)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_288_pos" x="0" y="(-319.5+288)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_289_pos" x="0" y="(-319.5+289)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_290_pos" x="0" y="(-319.5+290)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_291_pos" x="0" y="(-319.5+291)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_292_pos" x="0" y="(-319.5+292)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_293_pos" x="0" y="(-319.5+293)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_294_pos" x="0" y="(-319.5+294)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_295_pos" x="0" y="(-319.5+295)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_296_pos" x="0" y="(-319.5+296)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_297_pos" x="0" y="(-319.5+297)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_298_pos" x="0" y="(-319.5+298)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_299_pos" x="0" y="(-319.5+299)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_300_pos" x="0" y="(-319.5+300)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_301_pos" x="0" y="(-319.5+301)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_302_pos" x="0" y="(-319.5+302)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_303_pos" x="0" y="(-319.5+303)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_304_pos" x="0" y="(-319.5+304)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_305_pos" x="0" y="(-319.5+305)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_306_pos" x="0" y="(-319.5+306)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_307_pos" x="0" y="(-319.5+307)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_308_pos" x="0" y="(-319.5+308)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_309_pos" x="0" y="(-319.5+309)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_310_pos" x="0" y="(-319.5+310)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_311_pos" x="0" y="(-319.5+311)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_312_pos" x="0" y="(-319.5+312)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_313_pos" x="0" y="(-319.5+313)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_314_pos" x="0" y="(-319.5+314)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_315_pos" x="0" y="(-319.5+315)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_316_pos" x="0" y="(-319.5+316)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_317_pos" x="0" y="(-319.5+317)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_318_pos" x="0" y="(-319.5+318)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_319_pos" x="0" y="(-319.5+319)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_320_pos" x="0" y="(-319.5+320)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_321_pos" x="0" y="(-319.5+321)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_322_pos" x="0" y="(-319.5+322)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_323_pos" x="0" y="(-319.5+323)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_324_pos" x="0" y="(-319.5+324)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_325_pos" x="0" y="(-319.5+325)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_326_pos" x="0" y="(-319.5+326)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_327_pos" x="0" y="(-319.5+327)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_328_pos" x="0" y="(-319.5+328)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_329_pos" x="0" y="(-319.5+329)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_330_pos" x="0" y="(-319.5+330)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_331_pos" x="0" y="(-319.5+331)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_332_pos" x="0" y="(-319.5+332)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_333_pos" x="0" y="(-319.5+333)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_334_pos" x="0" y="(-319.5+334)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_335_pos" x="0" y="(-319.5+335)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_336_pos" x="0" y="(-319.5+336)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_337_pos" x="0" y="(-319.5+337)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_338_pos" x="0" y="(-319.5+338)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_339_pos" x="0" y="(-319.5+339)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_340_pos" x="0" y="(-319.5+340)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_341_pos" x="0" y="(-319.5+341)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_342_pos" x="0" y="(-319.5+342)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_343_pos" x="0" y="(-319.5+343)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_344_pos" x="0" y="(-319.5+344)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_345_pos" x="0" y="(-319.5+345)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_346_pos" x="0" y="(-319.5+346)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_347_pos" x="0" y="(-319.5+347)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_348_pos" x="0" y="(-319.5+348)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_349_pos" x="0" y="(-319.5+349)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_350_pos" x="0" y="(-319.5+350)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_351_pos" x="0" y="(-319.5+351)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_352_pos" x="0" y="(-319.5+352)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_353_pos" x="0" y="(-319.5+353)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_354_pos" x="0" y="(-319.5+354)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_355_pos" x="0" y="(-319.5+355)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_356_pos" x="0" y="(-319.5+356)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_357_pos" x="0" y="(-319.5+357)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_358_pos" x="0" y="(-319.5+358)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_359_pos" x="0" y="(-319.5+359)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_360_pos" x="0" y="(-319.5+360)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_361_pos" x="0" y="(-319.5+361)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_362_pos" x="0" y="(-319.5+362)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_363_pos" x="0" y="(-319.5+363)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_364_pos" x="0" y="(-319.5+364)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_365_pos" x="0" y="(-319.5+365)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_366_pos" x="0" y="(-319.5+366)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_367_pos" x="0" y="(-319.5+367)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_368_pos" x="0" y="(-319.5+368)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_369_pos" x="0" y="(-319.5+369)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_370_pos" x="0" y="(-319.5+370)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_371_pos" x="0" y="(-319.5+371)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_372_pos" x="0" y="(-319.5+372)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_373_pos" x="0" y="(-319.5+373)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_374_pos" x="0" y="(-319.5+374)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_375_pos" x="0" y="(-319.5+375)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_376_pos" x="0" y="(-319.5+376)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_377_pos" x="0" y="(-319.5+377)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_378_pos" x="0" y="(-319.5+378)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_379_pos" x="0" y="(-319.5+379)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_380_pos" x="0" y="(-319.5+380)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_381_pos" x="0" y="(-319.5+381)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_382_pos" x="0" y="(-319.5+382)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_383_pos" x="0" y="(-319.5+383)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_384_pos" x="0" y="(-319.5+384)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_385_pos" x="0" y="(-319.5+385)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_386_pos" x="0" y="(-319.5+386)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_387_pos" x="0" y="(-319.5+387)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_388_pos" x="0" y="(-319.5+388)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_389_pos" x="0" y="(-319.5+389)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_390_pos" x="0" y="(-319.5+390)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_391_pos" x="0" y="(-319.5+391)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_392_pos" x="0" y="(-319.5+392)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_393_pos" x="0" y="(-319.5+393)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_394_pos" x="0" y="(-319.5+394)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_395_pos" x="0" y="(-319.5+395)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_396_pos" x="0" y="(-319.5+396)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_397_pos" x="0" y="(-319.5+397)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_398_pos" x="0" y="(-319.5+398)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_399_pos" x="0" y="(-319.5+399)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_400_pos" x="0" y="(-319.5+400)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_401_pos" x="0" y="(-319.5+401)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_402_pos" x="0" y="(-319.5+402)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_403_pos" x="0" y="(-319.5+403)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_404_pos" x="0" y="(-319.5+404)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_405_pos" x="0" y="(-319.5+405)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_406_pos" x="0" y="(-319.5+406)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_407_pos" x="0" y="(-319.5+407)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_408_pos" x="0" y="(-319.5+408)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_409_pos" x="0" y="(-319.5+409)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_410_pos" x="0" y="(-319.5+410)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_411_pos" x="0" y="(-319.5+411)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_412_pos" x="0" y="(-319.5+412)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_413_pos" x="0" y="(-319.5+413)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_414_pos" x="0" y="(-319.5+414)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_415_pos" x="0" y="(-319.5+415)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_416_pos" x="0" y="(-319.5+416)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_417_pos" x="0" y="(-319.5+417)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_418_pos" x="0" y="(-319.5+418)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_419_pos" x="0" y="(-319.5+419)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_420_pos" x="0" y="(-319.5+420)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_421_pos" x="0" y="(-319.5+421)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_422_pos" x="0" y="(-319.5+422)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_423_pos" x="0" y="(-319.5+423)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_424_pos" x="0" y="(-319.5+424)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_425_pos" x="0" y="(-319.5+425)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_426_pos" x="0" y="(-319.5+426)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_427_pos" x="0" y="(-319.5+427)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_428_pos" x="0" y="(-319.5+428)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_429_pos" x="0" y="(-319.5+429)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_430_pos" x="0" y="(-319.5+430)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_431_pos" x="0" y="(-319.5+431)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_432_pos" x="0" y="(-319.5+432)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_433_pos" x="0" y="(-319.5+433)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_434_pos" x="0" y="(-319.5+434)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_435_pos" x="0" y="(-319.5+435)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_436_pos" x="0" y="(-319.5+436)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_437_pos" x="0" y="(-319.5+437)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_438_pos" x="0" y="(-319.5+438)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_439_pos" x="0" y="(-319.5+439)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_440_pos" x="0" y="(-319.5+440)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_441_pos" x="0" y="(-319.5+441)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_442_pos" x="0" y="(-319.5+442)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_443_pos" x="0" y="(-319.5+443)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_444_pos" x="0" y="(-319.5+444)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_445_pos" x="0" y="(-319.5+445)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_446_pos" x="0" y="(-319.5+446)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_447_pos" x="0" y="(-319.5+447)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_448_pos" x="0" y="(-319.5+448)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_449_pos" x="0" y="(-319.5+449)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_450_pos" x="0" y="(-319.5+450)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_451_pos" x="0" y="(-319.5+451)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_452_pos" x="0" y="(-319.5+452)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_453_pos" x="0" y="(-319.5+453)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_454_pos" x="0" y="(-319.5+454)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_455_pos" x="0" y="(-319.5+455)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_456_pos" x="0" y="(-319.5+456)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_457_pos" x="0" y="(-319.5+457)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_458_pos" x="0" y="(-319.5+458)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_459_pos" x="0" y="(-319.5+459)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_460_pos" x="0" y="(-319.5+460)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_461_pos" x="0" y="(-319.5+461)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_462_pos" x="0" y="(-319.5+462)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_463_pos" x="0" y="(-319.5+463)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_464_pos" x="0" y="(-319.5+464)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_465_pos" x="0" y="(-319.5+465)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_466_pos" x="0" y="(-319.5+466)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_467_pos" x="0" y="(-319.5+467)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_468_pos" x="0" y="(-319.5+468)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_469_pos" x="0" y="(-319.5+469)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_470_pos" x="0" y="(-319.5+470)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_471_pos" x="0" y="(-319.5+471)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_472_pos" x="0" y="(-319.5+472)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_473_pos" x="0" y="(-319.5+473)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_474_pos" x="0" y="(-319.5+474)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_475_pos" x="0" y="(-319.5+475)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_476_pos" x="0" y="(-319.5+476)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_477_pos" x="0" y="(-319.5+477)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_478_pos" x="0" y="(-319.5+478)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_479_pos" x="0" y="(-319.5+479)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_480_pos" x="0" y="(-319.5+480)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_481_pos" x="0" y="(-319.5+481)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_482_pos" x="0" y="(-319.5+482)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_483_pos" x="0" y="(-319.5+483)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_484_pos" x="0" y="(-319.5+484)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_485_pos" x="0" y="(-319.5+485)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_486_pos" x="0" y="(-319.5+486)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_487_pos" x="0" y="(-319.5+487)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_488_pos" x="0" y="(-319.5+488)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_489_pos" x="0" y="(-319.5+489)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_490_pos" x="0" y="(-319.5+490)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_491_pos" x="0" y="(-319.5+491)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_492_pos" x="0" y="(-319.5+492)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_493_pos" x="0" y="(-319.5+493)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_494_pos" x="0" y="(-319.5+494)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_495_pos" x="0" y="(-319.5+495)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_496_pos" x="0" y="(-319.5+496)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_497_pos" x="0" y="(-319.5+497)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_498_pos" x="0" y="(-319.5+498)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_499_pos" x="0" y="(-319.5+499)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_500_pos" x="0" y="(-319.5+500)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_501_pos" x="0" y="(-319.5+501)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_502_pos" x="0" y="(-319.5+502)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_503_pos" x="0" y="(-319.5+503)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_504_pos" x="0" y="(-319.5+504)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_505_pos" x="0" y="(-319.5+505)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_506_pos" x="0" y="(-319.5+506)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_507_pos" x="0" y="(-319.5+507)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_508_pos" x="0" y="(-319.5+508)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_509_pos" x="0" y="(-319.5+509)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_510_pos" x="0" y="(-319.5+510)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_511_pos" x="0" y="(-319.5+511)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_512_pos" x="0" y="(-319.5+512)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_513_pos" x="0" y="(-319.5+513)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_514_pos" x="0" y="(-319.5+514)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_515_pos" x="0" y="(-319.5+515)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_516_pos" x="0" y="(-319.5+516)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_517_pos" x="0" y="(-319.5+517)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_518_pos" x="0" y="(-319.5+518)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_519_pos" x="0" y="(-319.5+519)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_520_pos" x="0" y="(-319.5+520)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_521_pos" x="0" y="(-319.5+521)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_522_pos" x="0" y="(-319.5+522)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_523_pos" x="0" y="(-319.5+523)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_524_pos" x="0" y="(-319.5+524)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_525_pos" x="0" y="(-319.5+525)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_526_pos" x="0" y="(-319.5+526)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_527_pos" x="0" y="(-319.5+527)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_528_pos" x="0" y="(-319.5+528)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_529_pos" x="0" y="(-319.5+529)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_530_pos" x="0" y="(-319.5+530)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_531_pos" x="0" y="(-319.5+531)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_532_pos" x="0" y="(-319.5+532)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_533_pos" x="0" y="(-319.5+533)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_534_pos" x="0" y="(-319.5+534)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_535_pos" x="0" y="(-319.5+535)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_536_pos" x="0" y="(-319.5+536)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_537_pos" x="0" y="(-319.5+537)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_538_pos" x="0" y="(-319.5+538)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_539_pos" x="0" y="(-319.5+539)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_540_pos" x="0" y="(-319.5+540)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_541_pos" x="0" y="(-319.5+541)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_542_pos" x="0" y="(-319.5+542)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_543_pos" x="0" y="(-319.5+543)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_544_pos" x="0" y="(-319.5+544)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_545_pos" x="0" y="(-319.5+545)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_546_pos" x="0" y="(-319.5+546)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_547_pos" x="0" y="(-319.5+547)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_548_pos" x="0" y="(-319.5+548)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_549_pos" x="0" y="(-319.5+549)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_550_pos" x="0" y="(-319.5+550)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_551_pos" x="0" y="(-319.5+551)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_552_pos" x="0" y="(-319.5+552)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_553_pos" x="0" y="(-319.5+553)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_554_pos" x="0" y="(-319.5+554)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_555_pos" x="0" y="(-319.5+555)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_556_pos" x="0" y="(-319.5+556)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_557_pos" x="0" y="(-319.5+557)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_558_pos" x="0" y="(-319.5+558)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_559_pos" x="0" y="(-319.5+559)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_560_pos" x="0" y="(-319.5+560)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_561_pos" x="0" y="(-319.5+561)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_562_pos" x="0" y="(-319.5+562)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_563_pos" x="0" y="(-319.5+563)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_564_pos" x="0" y="(-319.5+564)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_565_pos" x="0" y="(-319.5+565)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_566_pos" x="0" y="(-319.5+566)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_567_pos" x="0" y="(-319.5+567)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_568_pos" x="0" y="(-319.5+568)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_569_pos" x="0" y="(-319.5+569)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_570_pos" x="0" y="(-319.5+570)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_571_pos" x="0" y="(-319.5+571)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_572_pos" x="0" y="(-319.5+572)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_573_pos" x="0" y="(-319.5+573)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_574_pos" x="0" y="(-319.5+574)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_575_pos" x="0" y="(-319.5+575)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_576_pos" x="0" y="(-319.5+576)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_577_pos" x="0" y="(-319.5+577)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_578_pos" x="0" y="(-319.5+578)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_579_pos" x="0" y="(-319.5+579)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_580_pos" x="0" y="(-319.5+580)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_581_pos" x="0" y="(-319.5+581)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_582_pos" x="0" y="(-319.5+582)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_583_pos" x="0" y="(-319.5+583)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_584_pos" x="0" y="(-319.5+584)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_585_pos" x="0" y="(-319.5+585)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_586_pos" x="0" y="(-319.5+586)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_587_pos" x="0" y="(-319.5+587)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_588_pos" x="0" y="(-319.5+588)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_589_pos" x="0" y="(-319.5+589)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_590_pos" x="0" y="(-319.5+590)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_591_pos" x="0" y="(-319.5+591)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_592_pos" x="0" y="(-319.5+592)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_593_pos" x="0" y="(-319.5+593)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_594_pos" x="0" y="(-319.5+594)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_595_pos" x="0" y="(-319.5+595)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_596_pos" x="0" y="(-319.5+596)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_597_pos" x="0" y="(-319.5+597)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_598_pos" x="0" y="(-319.5+598)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_599_pos" x="0" y="(-319.5+599)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_600_pos" x="0" y="(-319.5+600)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_601_pos" x="0" y="(-319.5+601)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_602_pos" x="0" y="(-319.5+602)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_603_pos" x="0" y="(-319.5+603)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_604_pos" x="0" y="(-319.5+604)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_605_pos" x="0" y="(-319.5+605)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_606_pos" x="0" y="(-319.5+606)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_607_pos" x="0" y="(-319.5+607)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_608_pos" x="0" y="(-319.5+608)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_609_pos" x="0" y="(-319.5+609)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_610_pos" x="0" y="(-319.5+610)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_611_pos" x="0" y="(-319.5+611)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_612_pos" x="0" y="(-319.5+612)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_613_pos" x="0" y="(-319.5+613)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_614_pos" x="0" y="(-319.5+614)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_615_pos" x="0" y="(-319.5+615)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_616_pos" x="0" y="(-319.5+616)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_617_pos" x="0" y="(-319.5+617)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_618_pos" x="0" y="(-319.5+618)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_619_pos" x="0" y="(-319.5+619)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_620_pos" x="0" y="(-319.5+620)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_621_pos" x="0" y="(-319.5+621)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_622_pos" x="0" y="(-319.5+622)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_623_pos" x="0" y="(-319.5+623)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_624_pos" x="0" y="(-319.5+624)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_625_pos" x="0" y="(-319.5+625)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_626_pos" x="0" y="(-319.5+626)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_627_pos" x="0" y="(-319.5+627)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_628_pos" x="0" y="(-319.5+628)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_629_pos" x="0" y="(-319.5+629)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_630_pos" x="0" y="(-319.5+630)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_631_pos" x="0" y="(-319.5+631)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_632_pos" x="0" y="(-319.5+632)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_633_pos" x="0" y="(-319.5+633)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_634_pos" x="0" y="(-319.5+634)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_635_pos" x="0" y="(-319.5+635)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_636_pos" x="0" y="(-319.5+636)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_637_pos" x="0" y="(-319.5+637)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_638_pos" x="0" y="(-319.5+638)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<position name="ssd_chan_639_pos" x="0" y="(-319.5+639)*(ssdD0_chanwidth+ssdD0_changap)" z="0"/>
+	<!-- ABOVE IS FOR SSD -->
+	<!-- BELOW IS FOR ARICH -->
+
+	<quantity name="arich_shift" value="1862.82" unit="mm"/>
+	<quantity name="arich_thick" value="280.0" unit="mm"/>
+	<quantity name="arich_width" value="365.0" unit="mm"/>
+	<quantity name="arich_height" value="365.0" unit="mm"/>
+
+	<position name="arich_pos" x="0" y="0" z="arich_shift+0.5*arich_thick" />
+	<quantity name="aerogel_thick0" value="18.9" unit="mm"/>
+	<quantity name="aerogel_thick1" value="20.4" unit="mm"/>
+	<quantity name="aerogel_size" value="93.0" unit="mm"/>
+	<quantity name="aerogel_shift" value="43.0" unit="mm"/>
+	 
+	<position name="aerogel_pos0" x="0" y="0" z="aerogel_shift-0.5*arich_thick+0.5*aerogel_thick0" />
+	<position name="aerogel_pos1" x="0" y="0" z="aerogel_shift-0.5*arich_thick+aerogel_thick0+0.5*aerogel_thick1" />
+
+	<quantity name="mPMT_thick" value="16.4" unit="mm"/>
+	<quantity name="mPMT_size" value="49.3" unit="mm"/>
+	<quantity name="mPMT_gap" value="5.4" unit="mm"/>
+	<quantity name="manode_size" value="6.0" unit="mm"/>
+	<quantity name="mPMT_shift" value="103.0" unit="mm"/>
+
+	<position name="mPMT0_0_anode0_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode0_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode0_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode0_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode0_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode0_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode0_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode0_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode1_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode1_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode1_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode1_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode1_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode1_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode1_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode1_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode2_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode2_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode2_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode2_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode2_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode2_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode2_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode2_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode3_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode3_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode3_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode3_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode3_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode3_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode3_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode3_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode4_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode4_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode4_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode4_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode4_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode4_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode4_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode4_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode5_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode5_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode5_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode5_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode5_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode5_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode5_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode5_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode6_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode6_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode6_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode6_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode6_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode6_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode6_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode6_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode7_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode7_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode7_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode7_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode7_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode7_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode7_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_0_anode7_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode0_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode0_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode0_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode0_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode0_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode0_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode0_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode0_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode1_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode1_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode1_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode1_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode1_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode1_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode1_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode1_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode2_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode2_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode2_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode2_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode2_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode2_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode2_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode2_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode3_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode3_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode3_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode3_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode3_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode3_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode3_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode3_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode4_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode4_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode4_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode4_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode4_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode4_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode4_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode4_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode5_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode5_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode5_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode5_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode5_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode5_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode5_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode5_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode6_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode6_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode6_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode6_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode6_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode6_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode6_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode6_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode7_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode7_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode7_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode7_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode7_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode7_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode7_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_1_anode7_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode0_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode0_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode0_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode0_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode0_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode0_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode0_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode0_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode1_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode1_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode1_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode1_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode1_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode1_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode1_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode1_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode2_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode2_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode2_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode2_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode2_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode2_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode2_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode2_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode3_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode3_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode3_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode3_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode3_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode3_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode3_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode3_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode4_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode4_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode4_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode4_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode4_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode4_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode4_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode4_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode5_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode5_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode5_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode5_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode5_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode5_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode5_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode5_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode6_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode6_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode6_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode6_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode6_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode6_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode6_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode6_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode7_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode7_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode7_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode7_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode7_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode7_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode7_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT0_2_anode7_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode0_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode0_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode0_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode0_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode0_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode0_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode0_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode0_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode1_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode1_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode1_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode1_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode1_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode1_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode1_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode1_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode2_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode2_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode2_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode2_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode2_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode2_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode2_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode2_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode3_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode3_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode3_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode3_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode3_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode3_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode3_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode3_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode4_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode4_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode4_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode4_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode4_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode4_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode4_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode4_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode5_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode5_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode5_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode5_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode5_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode5_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode5_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode5_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode6_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode6_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode6_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode6_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode6_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode6_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode6_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode6_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode7_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode7_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode7_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode7_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode7_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode7_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode7_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_0_anode7_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode0_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode0_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode0_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode0_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode0_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode0_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode0_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode0_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode1_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode1_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode1_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode1_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode1_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode1_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode1_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode1_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode2_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode2_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode2_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode2_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode2_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode2_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode2_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode2_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode3_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode3_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode3_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode3_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode3_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode3_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode3_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode3_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode4_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode4_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode4_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode4_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode4_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode4_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode4_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode4_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode5_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode5_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode5_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode5_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode5_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode5_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode5_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode5_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode6_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode6_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode6_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode6_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode6_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode6_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode6_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode6_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode7_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode7_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode7_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode7_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode7_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode7_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode7_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_1_anode7_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode0_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode0_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode0_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode0_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode0_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode0_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode0_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode0_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode1_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode1_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode1_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode1_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode1_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode1_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode1_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode1_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode2_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode2_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode2_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode2_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode2_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode2_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode2_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode2_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode3_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode3_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode3_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode3_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode3_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode3_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode3_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode3_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode4_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode4_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode4_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode4_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode4_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode4_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode4_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode4_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode5_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode5_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode5_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode5_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode5_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode5_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode5_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode5_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode6_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode6_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode6_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode6_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode6_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode6_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode6_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode6_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode7_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode7_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode7_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode7_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode7_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode7_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode7_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT1_2_anode7_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode0_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode0_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode0_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode0_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode0_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode0_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode0_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode0_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode1_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode1_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode1_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode1_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode1_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode1_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode1_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode1_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode2_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode2_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode2_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode2_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode2_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode2_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode2_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode2_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode3_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode3_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode3_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode3_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode3_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode3_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode3_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode3_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode4_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode4_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode4_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode4_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode4_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode4_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode4_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode4_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode5_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode5_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode5_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode5_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode5_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode5_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode5_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode5_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode6_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode6_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode6_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode6_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode6_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode6_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode6_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode6_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode7_0_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode7_1_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode7_2_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode7_3_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode7_4_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode7_5_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode7_6_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_0_anode7_7_pos" x="(-1+0)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode0_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode0_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode0_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode0_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode0_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode0_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode0_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode0_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode1_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode1_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode1_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode1_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode1_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode1_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode1_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode1_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode2_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode2_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode2_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode2_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode2_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode2_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode2_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode2_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode3_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode3_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode3_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode3_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode3_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode3_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode3_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode3_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode4_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode4_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode4_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode4_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode4_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode4_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode4_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode4_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode5_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode5_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode5_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode5_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode5_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode5_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode5_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode5_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode6_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode6_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode6_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode6_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode6_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode6_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode6_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode6_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode7_0_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode7_1_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode7_2_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode7_3_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode7_4_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode7_5_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode7_6_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_1_anode7_7_pos" x="(-1+1)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode0_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode0_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode0_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode0_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode0_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode0_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode0_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode0_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode1_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode1_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode1_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode1_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode1_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode1_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode1_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode1_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode2_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode2_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode2_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode2_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode2_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode2_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode2_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode2_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode3_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode3_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode3_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode3_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode3_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode3_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode3_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode3_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode4_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode4_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode4_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode4_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode4_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode4_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode4_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode4_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode5_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode5_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode5_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode5_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode5_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode5_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode5_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode5_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode6_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode6_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode6_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode6_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode6_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode6_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode6_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode6_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode7_0_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+0)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode7_1_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+1)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode7_2_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+2)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode7_3_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+3)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode7_4_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+4)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode7_5_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+5)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode7_6_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+6)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+	<position name="mPMT2_2_anode7_7_pos" x="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" y="(-1+2)*(mPMT_size+mPMT_gap)+(-3.5+7)*manode_size" z="mPMT_shift+0.5*mPMT_thick" />
+
+ 
+	<quantity name="PMTplate_thick" value="5.8" unit="mm"/>
+	<quantity name="PMTplate_size" value="195.7" unit="mm"/>
+
+	<position name="PMTplate_pos" x="0" y="0" z="mPMT_shift+mPMT_thick+0.5*PMTplate_thick" />
+	<!-- ABOVE IS FOR ARICH -->
+
+	 <!-- BELOW IS FOR RPC -->
+
+	 <quantity name="RPC_thick" value="54" unit="mm" />
+	 <quantity name="RPC_width" value="1066" unit="mm" />
+	 <quantity name="RPC_height" value="252" unit="mm" />
+	 <quantity name="RPC_volume_thick" value="200" unit="mm" />
+	 <quantity name="RPC0_shift" value="3953.38" unit="mm" />
+	 <quantity name="RPC1_shift" value="4050.39" unit="mm" />
+	 <quantity name="RPC_shift" value="4028.89" unit="mm" />
+
+	 <quantity name="RPC_Al_thick" value="1" unit="mm" />
+	 <quantity name="RPC_comb_thick" value="17" unit="mm" />
+	 <quantity name="RPC_PCB_thick" value="1" unit="mm" />
+	 <quantity name="RPC_acrylic_thick" value="1" unit="mm" />
+	 <quantity name="RPC_gas_width" value="960.5" unit="mm" />
+	 <quantity name="RPC_gas_height" value="250.5" unit="mm" />
+	 <quantity name="RPC_gas_thick" value="6" unit="mm" />
+
+	 <position name="RPC_pos" z="RPC_shift" unit="mm" />
+     <position name="RPC0_pos" z="RPC0_shift+0.5*RPC_thick-RPC_shift"/>
+     <position name="RPC0_Al0_pos" z="RPC_thick*(0-(2-1)*0.5)+RPC0_shift+0.5*RPC_thick-RPC_shift"/>
+     <position name="RPC0_Al1_pos" z="RPC_thick*(1-(2-1)*0.5)+RPC0_shift+0.5*RPC_thick-RPC_shift"/>
+     <position name="RPC1_pos" z="RPC1_shift+0.5*RPC_thick-RPC_shift"/>
+     <position name="RPC1_Al0_pos" z="RPC_thick*(0-(2-1)*0.5)+RPC1_shift+0.5*RPC_thick-RPC_shift"/>
+     <position name="RPC1_Al1_pos" z="RPC_thick*(1-(2-1)*0.5)+RPC1_shift+0.5*RPC_thick-RPC_shift"/>
+	 <!-- ABOVE IS FOR RPC -->
+
+	<!-- BELOW IS FOR LG -->
+
+    <quantity name="LG_length" value="340" unit="mm" />
+    <quantity name="LG_height" value="122" unit="mm" />
+    <quantity name="LG_width0" value="113" unit="mm" />
+    <quantity name="LG_width1" value="135" unit="mm" />
+    <quantity name="LG_width1T" value="145.4824" unit="mm" />
+    <quantity name="LG_angle" value="3.7074" unit="degree"/>
+    <quantity name="LG_TransHorOff_shift" value="2." unit="mm" />
+    <quantity name="LG_protrusion_thick" value="40" unit="mm" />
+    <quantity name="LG_PMTr" value="38" unit="mm" />
+    <quantity name="LG_PMTl" value="120" unit="mm" />
+
+    <position name="LG_trap_pos1" x="0" y="0" z="-0.5*(LG_TransHorOff_shift+LG_length+LG_protrusion_thick+LG_PMTl-LG_length)"/>
+	<position name="LG_protrusion_pos" x="0" y="0" z="LG_length-0.5*(LG_TransHorOff_shift+LG_length+LG_protrusion_thick+LG_PMTl)+0.5*LG_protrusion_thick"/>
+	<position name="LG_PMT_pos" x="0" y="0" z="LG_length-0.5*(LG_TransHorOff_shift+LG_length+LG_protrusion_thick+LG_PMTl)+LG_protrusion_thick+0.5*LG_PMTl"/>
+
+	<position name="LG_block00_pos" x="(0.5*(LG_width0+LG_width1T)+LG_TransHorOff_shift+Tolerance_space)" y="LG_height*(0-1)+2.5*(0-1)" z="0."/>
+	<position name="LG_block01_pos" x="0" y="LG_height*(0-1)+2.5*(0-1)" z="0"/>
+	<position name="LG_block02_pos" x="-(0.5*(LG_width0+LG_width1T)+LG_TransHorOff_shift+Tolerance_space)" y="LG_height*(0-1)+2.5*(0-1)" z="0."/>
+	<rotation name="LG_block00_rot" x="0" y="-1.0*LG_angle" z="0" />
+	<rotation name="LG_block01_rot" x="0" y="0" z="0" />
+	<rotation name="LG_block02_rot" x="0" y="LG_angle" z="0" />
+	<position name="LG_block10_pos" x="(0.5*(LG_width0+LG_width1T)+LG_TransHorOff_shift+Tolerance_space)" y="LG_height*(1-1)+2.5*(1-1)" z="0."/>
+	<position name="LG_block11_pos" x="0" y="LG_height*(1-1)+2.5*(1-1)" z="0"/>
+	<position name="LG_block12_pos" x="-(0.5*(LG_width0+LG_width1T)+LG_TransHorOff_shift+Tolerance_space)" y="LG_height*(1-1)+2.5*(1-1)" z="0."/>
+	<rotation name="LG_block10_rot" x="0" y="-1.0*LG_angle" z="0" />
+	<rotation name="LG_block11_rot" x="0" y="0" z="0" />
+	<rotation name="LG_block12_rot" x="0" y="LG_angle" z="0" />
+	<position name="LG_block20_pos" x="(0.5*(LG_width0+LG_width1T)+LG_TransHorOff_shift+Tolerance_space)" y="LG_height*(2-1)+2.5*(2-1)" z="0."/>
+	<position name="LG_block21_pos" x="0" y="LG_height*(2-1)+2.5*(2-1)" z="0"/>
+	<position name="LG_block22_pos" x="-(0.5*(LG_width0+LG_width1T)+LG_TransHorOff_shift+Tolerance_space)" y="LG_height*(2-1)+2.5*(2-1)" z="0."/>
+	<rotation name="LG_block20_rot" x="0" y="-1.0*LG_angle" z="0" />
+	<rotation name="LG_block21_rot" x="0" y="0" z="0" />
+	<rotation name="LG_block22_rot" x="0" y="LG_angle" z="0" />
+	<quantity name="calor_length" value="520" unit="mm" />
+	<quantity name="calor_height" value="380" unit="mm" />
+	<quantity name="calor_width" value="900" unit="mm" />
+    <quantity name="calor_shift" value="4286.4" unit="mm" />
+    <position name="calor_pos" x="0" y="0" z="calor_shift+calor_length*0.5"/>
+
+	 <!-- ABOVE IS FOR LG -->
+
+  
 
 	<!-- ********** Refractive index ********** -->
 

--- a/Geometry/gdml/phase1c/generate_gdml.pl
+++ b/Geometry/gdml/phase1c/generate_gdml.pl
@@ -503,6 +503,8 @@ EOF
  <!-- ABOVE IS FOR MAGNET -->
 
 EOF
+
+  }
   
   if($SSD_switch) {
 	  gen_SSD_Define(\*DEF);
@@ -1646,5 +1648,4 @@ EOF
 EOF
 
 	close(OUTPUT);
-}
 }


### PR DESCRIPTION
The `if($magnet_swtich)` section was missing a closing brace, so when magnet was set to 0, none of the remaining definitions made it into the gdml. I fixed it an remade the affected gdmls.