### PR TITLE
Fix: Using dchan.HiLo() for correct SSD hit sensor ID

### DIFF
--- a/CAFMaker/SSDHitsFiller.cxx
+++ b/CAFMaker/SSDHitsFiller.cxx
@@ -56,7 +56,7 @@ namespace caf
       srSSDHits.TrigNum = ssdhits[hitId].TrigNum();
       srSSDHits.Row = ssdhits[hitId].Row();
       srSSDHits.Station = dchan.Station();
-      srSSDHits.Sensor  = dchan.Channel();
+      srSSDHits.Sensor  = dchan.HiLo();
       srSSDHits.Plane = dchan.Plane();
    } // end for hitId
   }  


### PR DESCRIPTION
The sensor ID in the hit branch was inconsistent with the cluster branch. The hit branch was using an old channel number (0 to 27) instead of the local sensor ID (e.g., 0 or 1). With this change, the hit branch now has the correct physical sensor labels, resolving the inconsistency.