### PR TITLE
Fixed ARICH info not being written

### DIFF
--- a/CAFMaker/VertexFiller.cxx
+++ b/CAFMaker/VertexFiller.cxx
@@ -11,7 +11,7 @@
 #include "RecoBase/Track.h"
 //#include "StandardRecord/SRTrackSegment.h"
 #include "RecoBase/RecoBaseDefs.h"
-//#include "RecoBase/ArichID.h"
+#include "RecoBase/ArichID.h"
 
 namespace caf
 {
@@ -40,9 +40,16 @@ namespace caf
 
   //---------------------------------
 
-  caf::SRSecondaryTrack VertexFiller::GetSecondaryTrack(rb::Track& track, const std::vector<sim::SSDHit>& truehitv)
+  caf::SRSecondaryTrack VertexFiller::GetSecondaryTrack(rb::Track& track, const std::vector<sim::SSDHit>& truehitv, rb::ArichID& arichid)
   {
     caf::SRSecondaryTrack secTrk = track;
+    
+    //Inserting ARICH informations in track 
+    secTrk.arich.trackID = arichid.trackID;
+    secTrk.arich.scoresLL = arichid.scoresLL;
+    secTrk.arich.scoresML = arichid.scoresML;
+    secTrk.arich.nhit =  arichid.nhit;
+    
 
     if (! truehitv.empty()) {
       std::unordered_map<int,const sim::SSDHit*> ssdHitMap;
@@ -109,15 +116,20 @@ namespace caf
     auto hv = evt.getHandle<std::vector<rb::Vertex> >(fVertexLabel);
     auto ht = evt.getHandle<std::vector<rb::Track> >(fTrackLabel);
     auto truehitv = evt.getHandle<std::vector<sim::SSDHit> >(fSSDHitLabel);
+    auto ha = evt.getHandle<std::vector<rb::ArichID>> (fArichIDLabel);
+ 
     std::vector <rb::Vertex> vtxs;
     std::vector <rb::Track> trks;
     std::vector <sim::SSDHit> ssdhits;
+    std::vector <rb::ArichID> arichids;
 
     if ( !hv.failedToGet()) vtxs = *hv;
     if ( !ht.failedToGet()) trks = *ht;
     if ( !truehitv.failedToGet()) ssdhits = *truehitv;
+    if ( !ha.failedToGet()) arichids = *ha;
 
     stdrec.vtxs.nvtx = vtxs.size();
+
 
     // loop over vertices
     for (int iv= 0; iv< (int)vtxs.size();iv++) {
@@ -130,7 +142,9 @@ namespace caf
       // loop over secondary tracks in vertex
       for (size_t it=0; it < v.sectrkIdx.size(); ++it) {
         auto idx = v.sectrkIdx[it];
-        caf::SRSecondaryTrack srt = GetSecondaryTrack(trks[idx], ssdhits);
+	
+        //for now it's easy with single particle, arich ID always has one entry: the first
+        caf::SRSecondaryTrack srt = GetSecondaryTrack(trks[idx], ssdhits,arichids[0]);
         srv.Add(srt);
       }
       stdrec.vtxs.vtx.push_back(srv);

--- a/CAFMaker/VertexFiller.h
+++ b/CAFMaker/VertexFiller.h
@@ -20,7 +20,7 @@ namespace caf
     void Fill(art::Event&, caf::StandardRecord&);
     //void Fill(art::Event&, caf::StandardRecord& sr1,  caf::StandardRecord& sr2);
     void GetBeamTrackTruth(caf::SRBeamTrack&, const std::vector<sim::SSDHit> &);
-    caf::SRSecondaryTrack GetSecondaryTrack(rb::Track&, const std::vector<sim::SSDHit> &);
+    caf::SRSecondaryTrack GetSecondaryTrack(rb::Track&, const std::vector<sim::SSDHit> &, rb::ArichID&);
     std::string fVertexLabel;
     std::string fTrackLabel;
     std::string fArichIDLabel;

--- a/CAFMaker/prod_reco_caf_job.fcl
+++ b/CAFMaker/prod_reco_caf_job.fcl
@@ -14,6 +14,8 @@
 #include "MakeTrackSegments.fcl"
 #include "MakeSingleTracks.fcl"
 #include "SingleTrackAlignment.fcl"
+#include "MakePrimaryVertex.fcl"
+
 
 process_name: CAF
 
@@ -53,13 +55,14 @@ physics:
     maketracksegments: @local::standard_maketracksegments
     makesingletracks: @local::standard_makesingletracks
     singletrackalignment: @local::standard_singletrackalignment
+    makeprimaryvertex: @local::standard_makeprimaryvertex
   }
 
   analyzers:{}
 
   makecaf:   [
                dataqual, spillinfo, arichcluster, clust,
-               maketracksegments, makesingletracks, arichring, arichreco, #singletrackalignment,
+               maketracksegments, makesingletracks, arichring, arichreco, makeprimaryvertex, #singletrackalignment,
               # adcreco, backovreco, gasckovreco,
                cafmaker
              ]


### PR DESCRIPTION
 TBrowser can't see them but a root macro can so all good ig
 
 Also, root complains about SRParticle for LastDaughter function which returns an rbegin() iterator. I commented it out on mine but it's not in this PR
 
 Also, let me know if I should push the BeamGen_module.CC (and fcl) with the possibility of having a flat Pz distribution (mean-sigma to mean+sigma)