### PR TITLE
fixing fcl keys in BeamGen

### DIFF
--- a/G4EMPH/BeamGen.fcl
+++ b/G4EMPH/BeamGen.fcl
@@ -15,7 +15,7 @@ standard_beamgen:
 
 #Note: units are cm, GeV.  "Px" = px/pz, "Py" = py/pz.
 
-  ZStart:                    -200.
+  Zstart:        -200.
 # parameters for flat spatial distribution
   Xmax:			     0. 
   Xmin:			     0. 
@@ -51,7 +51,7 @@ proton_sliced.UseRunHistory: true
 proton_sliced.particleType: "proton"
 proton_sliced.phaseSpaceSource: "Sliced"
 proton_sliced.Zstart: -3.0 
-proton_sliced.PSigma: 0.001 
+proton_sliced.Psigma: 0.001 
 proton_sliced.xHist1DFile: "/cvmfs/emphatic.opensciencegrid.org/beamProfiles/beam_profiles_master.root"
 proton_sliced.slicedHistsFile: "/cvmfs/emphatic.opensciencegrid.org/beamProfiles/beam_profiles_master.root"
 proton_sliced.xHist1DName: "hX_for_slicing"

--- a/G4EMPH/BeamGen_module.cc
+++ b/G4EMPH/BeamGen_module.cc
@@ -159,7 +159,7 @@ namespace emph {
 
     // NOTE: These are in units of GeV/c
     fPmean         = ps.get<double>("PMean",0.); 
-    fPsigma        = ps.get<double>("PSigma",0.);
+    fPsigma        = ps.get<double>("Psigma",0.);
     
     // NOTE: These are all in units of ??
     fXmax          = ps.get<double>("Xmax",-999999.); 


### PR DESCRIPTION
`ZStart` and `PSigma` in `BeamGen.fcl` didn't match the keys `BeamGen_module.cc` reads, so they were silently ignored. Renamed to `Zstart` and `Psigma` (also updated the C++ key and `proton_sliced` override) for consistency 