### PR TITLE
Fix secondary track SSD line segment filling

### DIFF
--- a/TrackReco/MakeSingleTracks_module.cc
+++ b/TrackReco/MakeSingleTracks_module.cc
@@ -465,7 +465,6 @@ namespace emph {
             // add TrackSegments to the track
             sectrk.Add(t2);
             sectrk.Add(t3);
-            AddSSDLineSegmentsToTrack(beamtrk);
             
             sectrk.mom = t2.mom; // this should come from an analysis of the bend angle between track segments 1 and 2.
             auto v = algo.SetTrackInfo(tsvec[0], tsvec[1]);


### PR DESCRIPTION
- Removed redundant `AddSSDLineSegmentsToTrack(beamtrk)` call.
- `beamtrk` is already filled earlier at line 450.
- `sectrk` is filled separately below at line 484 which is now line 483 now. 