### PR TITLE
Update two-track DOCA vertex calculation

### DIFF
--- a/CAFMaker/VertexFiller.cxx
+++ b/CAFMaker/VertexFiller.cxx
@@ -199,6 +199,7 @@ namespace caf
       caf::SRTrack tr1 = trks[0]; // beam track is always first track
       caf::SRBeamTrack btr;
       if (!ssdhits.empty()) btr = GetBeamTrack(trks[0], ssdhits);
+      else{
         for (size_t i=0; i<trks[0].NTrackSegments(); i++){     
           auto rbts = trks[0].GetTrackSegment(i);
           caf::SRTrackSegment srts;
@@ -212,7 +213,8 @@ namespace caf
           srts.thetaX = rbts->thetaX;
           srts.thetaY = rbts->thetaY;
           btr.Add(srts);
-        }
+	}
+      }
       srv.SetBeamTrack(btr);
       // loop over secondary tracks in vertex
       for (size_t it=0; it < v.sectrkIdx.size(); ++it) {

--- a/CAFMaker/VertexFiller.cxx
+++ b/CAFMaker/VertexFiller.cxx
@@ -199,7 +199,6 @@ namespace caf
       caf::SRTrack tr1 = trks[0]; // beam track is always first track
       caf::SRBeamTrack btr;
       if (!ssdhits.empty()) btr = GetBeamTrack(trks[0], ssdhits);
-      else{
         for (size_t i=0; i<trks[0].NTrackSegments(); i++){     
           auto rbts = trks[0].GetTrackSegment(i);
           caf::SRTrackSegment srts;
@@ -213,8 +212,7 @@ namespace caf
           srts.thetaX = rbts->thetaX;
           srts.thetaY = rbts->thetaY;
           btr.Add(srts);
-	}
-      }
+        }
       srv.SetBeamTrack(btr);
       // loop over secondary tracks in vertex
       for (size_t it=0; it < v.sectrkIdx.size(); ++it) {

--- a/VertexReco/PrimaryVertexAlgo.cxx
+++ b/VertexReco/PrimaryVertexAlgo.cxx
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////
 /// \brief   Class for primary vertex finding/fitting algorithm
-/// \author  Jon Paley
+/// \author  Jon Paley and Aayush Bhattarai
 /// \date    9/22/25
 ////////////////////////////////////////////////////////////////////////
 
@@ -38,33 +38,63 @@ namespace emph {
   {
     using namespace ROOT::Math;
 
+    vtx.sectrkIdx.clear();
+    vtx.pos.SetXYZ(99999., 99999., 99999.);
+
     if (trks.size() <= 1) return false;
 
     if (trks.size() == 2) {
- 
-      vtx.pos = (trks[1].posTrgt+trks[0].posTrgt)/2.;
-      //      vtx.pos.SetZ(-99999.);
-//      vtx.trkIdx.push_back(0);
-      vtx.sectrkIdx.push_back(1);
 
-//      auto trkMom = trks[1].momTrgt;
-//      trkMom.SetZ(-1.*trkMom.Z());
-      auto a = trks[0].momTrgt.Cross(-1*trks[1].momTrgt);
-//      auto a = trks[0].momTrgt.Cross(trkMom);
-      double dot = a.Dot(a);
+      // Modeling tracks as an infinite 3D lines:
+      //   track 0 (Beam track)     : C0(s) = P0 + s*d0
+      //   track 1 (Secondary track): C1(t) = P1 + t*d1
+      //
+      // For two reconstructed tracks, the lines usually do not intersect
+      // exactly. The DOCA vertex is taken to be the midpoint of the two
+      // points of closest approach.
 
-      if (dot == 0) {
-	std::cout<<"Uh oh, tracks are _exactly_ parallel!"<<std::endl;
-	return false;
+      auto P0 = trks[0].posTrgt; // trks[0] = beam track
+      auto P1 = trks[1].posTrgt; // trks[1] = secondary track
+      auto d0 = trks[0].momTrgt;
+      auto d1 = trks[1].momTrgt;
+
+      const double eps = 1.e-12;
+
+      const double d0mag2 = d0.Dot(d0);
+      const double d1mag2 = d1.Dot(d1);
+
+
+      // Reject tracks with zero/near-zero direction (degenerate input)
+      if (d0mag2 <= eps || d1mag2 <= eps) {
+        std::cerr << "FindVertexDOCA: track has zero or near-zero direction."
+                  << std::endl;
+        return false;
       }
 
-      auto ab = trks[1].posTrgt - trks[0].posTrgt;
-      auto b = ab.Cross(trks[1].momTrgt);
+      auto n = d0.Cross(d1);
+      const double denom = n.Dot(n);
 
-      double t = b.Dot(a) / dot;
-      vtx.pos = trks[1].posTrgt + t*trks[1].momTrgt;
-//      std::cout << "vtx.pos = " << vtx.pos << std::endl;
+      // denom = |d0 x d1|^2.
+      // If this is very small, the two tracks are parallel or nearly parallel.
+      if (denom <= eps*d0mag2*d1mag2) {
+        std::cerr << "FindVertexDOCA: tracks are parallel or nearly parallel."
+                  << std::endl;
+        return false;
+      }
 
+      auto r = P1 - P0; // displacement vector
+
+      // Parameters of closest approach on each track.
+      const double s = r.Cross(d1).Dot(n) / denom; // parameter on track 0
+      const double t = r.Cross(d0).Dot(n) / denom; // parameter on track 1
+
+      auto poca0 = P0 + s*d0;
+      auto poca1 = P1 + t*d1;
+
+      // DOCA vertex: midpoint between the two closest points.
+      vtx.pos = (poca0 + poca1)/2.;
+
+      vtx.sectrkIdx.push_back(1);
     }
     else {
       Vector3d b(0.,0.,0.);
@@ -96,7 +126,7 @@ namespace emph {
       // Solve A * x = b
       int ok = 0;
       Vector3d x = A.Inverse(ok) * b;
-      if (!ok)
+      if (ok)
       {
         std::cerr << "Matrix inversion failed (lines may be parallel/degenerate)." << std::endl;
         vtx.pos.SetXYZ(99999., 99999., 99999.);


### PR DESCRIPTION
This PR updates the two-track primary vertex reconstruction to use a direct two-line DOCA calculation.

Changes:
- Clears secondary track indices before filling
- Initializes the vertex failure state before reconstruction
- Adds checks for invalid and nearly parallel track directions
- Uses posTrgt/momTrgt as the track-level line representation for the DOCA calculation

Validation notes:
- I also tested an alternate line representation using the selected track-segment endpoints, pointA and pointB.
- The pointA/pointB representation and the posTrgt/momTrgt representation gave the same reconstructed DOCA vertex and DOCA value to floating-point precision.
- Since posTrgt/momTrgt are track-level quantities and give equivalent results, this PR keeps posTrgt/momTrgt in the main vertex algorithm.

This PR only changes the two-track case.