### PR TITLE
Fix null-pointer dereference in CAFMaker truth matching + leak and copies

### DIFF
--- a/CAFMaker/CAFMaker_module.cc
+++ b/CAFMaker/CAFMaker_module.cc
@@ -135,9 +135,9 @@ namespace caf {
     if (!fFile) {
       // Filename wasn't set in the FCL, and this is the
       // first file we've seen
-      char *temp = new char[fb.fileName().size() + 1];
-      std::strcpy(temp, fb.fileName().c_str());
-      fCAFFilename = basename(temp);
+      const std::string& fn = fb.fileName();
+      const size_t slashpos = fn.find_last_of('/');
+      fCAFFilename = (slashpos == std::string::npos) ? fn : fn.substr(slashpos + 1);
       // find last . in filename, drop everything after it and append .caf.root
       const size_t dotpos = fCAFFilename.find_last_of('.');
       assert(dotpos != std::string::npos);  // Must have a dot, surely?

--- a/CAFMaker/ClusterFiller.cxx
+++ b/CAFMaker/ClusterFiller.cxx
@@ -21,8 +21,8 @@ namespace caf
 		<< "' found under label '" << fLabel << "'. " << std::endl; //fLabel -> fParams.SSDClusterLabel()?
     }
 
-    std::vector<rb::SSDCluster>  ssdclusters;
-    if(!clusterv.failedToGet()) ssdclusters = *clusterv;
+    static const std::vector<rb::SSDCluster> emptyClusters;
+    const std::vector<rb::SSDCluster>& ssdclusters = clusterv.failedToGet() ? emptyClusters : *clusterv;
 
     for (unsigned int clusterId = 0; clusterId < ssdclusters.size(); ++ clusterId) {
       // clusters

--- a/CAFMaker/VertexFiller.cxx
+++ b/CAFMaker/VertexFiller.cxx
@@ -54,7 +54,7 @@ namespace caf
                isOk = false;
            }
          }
-	 if (abs(ssdHitMap[id]->PId()) == 11) isOk = false; // Don't include electrons/delta rays or positrons
+	 if (isOk && abs(ssdHitMap[id]->PId()) == 11) isOk = false; // Don't include electrons/delta rays or positrons
          if (isOk) {
            auto ssdhit = ssdHitMap[id];
            truth.pos.SetXYZ(ssdhit->X(),ssdhit->Y(),ssdhit->Z());
@@ -145,7 +145,7 @@ namespace caf
                 isOk = false;
             }
           }
-          if (abs(ssdHitMap[id]->PId()) == 11) isOk = false; // Don't include electrons/delta rays or positrons
+          if (isOk && abs(ssdHitMap[id]->PId()) == 11) isOk = false; // Don't include electrons/delta rays or positrons
           if (isOk) {
             auto ssdhit = ssdHitMap[id];
             truth.pos.SetXYZ(ssdhit->X(),ssdhit->Y(),ssdhit->Z());
@@ -179,14 +179,18 @@ namespace caf
     auto truehitv = evt.getHandle<std::vector<sim::SSDHit> >(fSSDHitLabel);
     auto ha = evt.getHandle<std::vector<rb::ArichID>> (fArichIDLabel);
  
-    std::vector <rb::Vertex> vtxs;
+    static const std::vector <rb::Vertex>  emptyVtxs;
+    static const std::vector <sim::SSDHit> emptySsdhits;
+
+    const std::vector <rb::Vertex>&  vtxs    = hv.failedToGet()       ? emptyVtxs    : *hv;
+    const std::vector <sim::SSDHit>& ssdhits = truehitv.failedToGet() ? emptySsdhits : *truehitv;
+
+    // trks and arichids are intentionally copied: their elements are passed to
+    // GetBeamTrack/GetSecondaryTrack, which take non-const rb::Track&/rb::ArichID&.
     std::vector <rb::Track> trks;
-    std::vector <sim::SSDHit> ssdhits;
     std::vector <rb::ArichID> arichids;
 
-    if ( !hv.failedToGet()) vtxs = *hv;
     if ( !ht.failedToGet()) trks = *ht;
-    if ( !truehitv.failedToGet()) ssdhits = *truehitv;
     if ( !ha.failedToGet()) arichids = *ha;
 
     stdrec.vtxs.nvtx = vtxs.size();


### PR DESCRIPTION
Part of #303.

## Fixes

**Null-pointer dereference in truth matching (`VertexFiller.cxx`, two occurrences).** The truth-match fallback tries `id`, `id+1`, `id-1` in `ssdHitMap`; when all three lookups fail it sets `isOk = false`, but the next line unconditionally evaluated `abs(ssdHitMap[id]->PId())`. On a missing key, `std::map::operator[]` inserts a null `sim::SSDHit*` which is immediately dereferenced — UB/crash whenever a track line segment has no nearby truth hit. Fixed with a short-circuit guard (`isOk && ...`); the id-fallback semantics are unchanged (when a lookup succeeds, `id` is left at the found key exactly as before).

**File-name buffer leak (`CAFMaker_module.cc::respondToOpenInputFile`).** `new char[]` + `strcpy` + `basename()`, never freed. Replaced with `std::string`-only basename logic; no raw buffer.

**Per-event product vector copies (`VertexFiller.cxx`, `ClusterFiller.cxx`).** Full copies of the vertex/SSD-hit/cluster product vectors per event replaced with const references (empty-vector fallback preserved). `trks` and `arichids` are deliberately left as copies: `GetBeamTrack`/`GetSecondaryTrack` take non-const `rb::Track&`/`rb::ArichID&`, so const-ref elements cannot bind — noted in a comment; changing those signatures is out of scope here.

## Verification
Behavior-preserving by construction except the dereference guard, whose before/after is described above (before: UB; after: the electron check is skipped only when no hit was found, in which case `isOk` already excluded the truth record). Downstream read-only use of the converted containers was checked. No local art/UPS build environment and no repo CI — **a collaborator build before undrafting would be appreciated.**

🤖 Assisted by Claude Code (claude-fable-5)
