### PR TITLE
SSDReco/TrackReco: fix X1 cluster check, const-ref digit list, range-for copies

### DIFF
--- a/SSDReco/MakeSSDClusters_module.cc
+++ b/SSDReco/MakeSSDClusters_module.cc
@@ -78,7 +78,7 @@ private:
 			   const art::Ptr<emph::rawdata::SSDRawDigit>& b);
   void SortByRow(art::PtrVector<emph::rawdata::SSDRawDigit>& dl);
 
-  void FormClusters(art::PtrVector<emph::rawdata::SSDRawDigit> sensDigits,
+  void FormClusters(const art::PtrVector<emph::rawdata::SSDRawDigit>& sensDigits,
 		    std::vector<rb::SSDCluster>* sensClusters,
 		    int station, int plane, int sensor);
 };
@@ -142,7 +142,7 @@ void emph::MakeSSDClusters::SortByRow(art::PtrVector<emph::rawdata::SSDRawDigit>
 }
 
 //--------------------------------------------------
-void emph::MakeSSDClusters::FormClusters(art::PtrVector<emph::rawdata::SSDRawDigit> sensDigits,
+void emph::MakeSSDClusters::FormClusters(const art::PtrVector<emph::rawdata::SSDRawDigit>& sensDigits,
 	       std::vector<rb::SSDCluster>* sensClusters,
 	       int station, int plane, int sensor)
 { 

--- a/SSDReco/experimental/SSDRecUpstreamTgtAutre.cxx
+++ b/SSDReco/experimental/SSDRecUpstreamTgtAutre.cxx
@@ -78,8 +78,8 @@ namespace emph {
       //
       // Require at least one cluster in each of the 2 X 2 view. 
       //
-      if ((mySSDClsPtrsX0.size() == 0) || (mySSDClsPtrsY0.size() == 0) || 
-          (mySSDClsPtrsY1.size() == 0) || (mySSDClsPtrsY1.size() == 0)) return 0;  
+      if ((mySSDClsPtrsX0.size() == 0) || (mySSDClsPtrsY0.size() == 0) ||
+          (mySSDClsPtrsX1.size() == 0) || (mySSDClsPtrsY1.size() == 0)) return 0;
       //
       // Could be stored in this clas..in some initialization, 
       // post delclaration of the Volatile Alignment data.  For sake of clarity, we leave it here.. 

--- a/TrackReco/MakeTrackSegments_module.cc
+++ b/TrackReco/MakeTrackSegments_module.cc
@@ -238,7 +238,7 @@ namespace emph {
             }
 
             for (size_t i = 0; i < clustMapAtLeastOne.size(); i++) {
-              for (auto j : clustMapAtLeastOne[i]) {
+              for (const auto& j : clustMapAtLeastOne[i]) {
                 mf::LogDebug("MakeTrackSegments") << "Station " << i << ": " << j.second;
               }
             }
@@ -282,7 +282,7 @@ namespace emph {
             // Make reconstructed hits
             spv = algo.MakeHits(ls_group, cl_group);
 
-            for (auto sp : spv)
+            for (const auto& sp : spv)
               spacepointv->push_back(sp);
 
             // Reconstructed hits
@@ -331,7 +331,7 @@ namespace emph {
                 if (i.chi2 < 5) chi2lessthan5_3++;
               }
 
-              for (auto ts : tsv) {
+              for (const auto& ts : tsv) {
                 tracksegmentv->push_back(ts);
               }
             }


### PR DESCRIPTION
Part of #303.

## Fixes

- **`SSDReco/experimental/SSDRecUpstreamTgtAutre.cxx`:** the "at least one cluster in each of the 2×2 views" requirement checked `mySSDClsPtrsY1` twice and `mySSDClsPtrsX1` never (copy-paste). Now checks X0, Y0, X1, Y1 as the comment intends. (Empty X1 previously fell through to produce zero candidates downstream, so physics output should be unchanged; the intended early return is restored.)
- **`SSDReco/MakeSSDClusters_module.cc`:** `FormClusters` took its `art::PtrVector<SSDRawDigit>` by value, called per sensor per event. The body is read-only with respect to the digit list (sorting happens in the caller beforehand) — now passed by const reference.
- **`TrackReco/MakeTrackSegments_module.cc`:** three range-for loops copied non-trivial objects (`SpacePoint`, `TrackSegment`, map pairs) per iteration — now `const auto&`. Three similar-looking loops were deliberately **not** converted because their bodies mutate the loop copy (`i.region = kRegionN` before `push_back`).

## Verification
Behavior-preserving by construction. No local build environment and no repo CI — **a collaborator build before undrafting would be appreciated.**

🤖 Assisted by Claude Code (claude-fable-5)
