### PR TITLE
Core correctness: CovMatrix stride, eigenvector guard, std::abs

### DIFF
--- a/Geometry/Geometry.cxx
+++ b/Geometry/Geometry.cxx
@@ -6,6 +6,7 @@
 ////////////////////////////////////////////////////////////////////////
 
 #include <cassert>
+#include <cmath>
 #include <iostream>
 #include <fstream>
 #include <stdio.h>
@@ -94,10 +95,10 @@ namespace emph {
      float ang = this->Rot();
 
      // x-view: π/2, 3π/2
-     if ( abs(sin(ang-pi/2)) < 0.2)
+     if ( std::abs(sin(ang-pi/2)) < 0.2)
          return X_VIEW;
      // y-view: 0,π
-     else if (abs(sin(ang)) < 0.2)
+     else if (std::abs(sin(ang)) < 0.2)
          return Y_VIEW;
 
      // Flipped diagonal sensors have a Rot angle π/2 out-of-phase
@@ -105,10 +106,10 @@ namespace emph {
      // Adding earlier messes up x,y double sensor planes.
      ang += pi/2*this->IsFlip();
      // u-view: 3π/4, 7π/4
-     if (abs(sin(ang-3*pi/4)) < 0.2)
+     if (std::abs(sin(ang-3*pi/4)) < 0.2)
          return W_VIEW;
      // w-view: π/4, 5π/4
-     else if (abs(sin(ang-pi/4)) < 0.2)
+     else if (std::abs(sin(ang-pi/4)) < 0.2)
          return U_VIEW;
      return INIT;
     }

--- a/RecoBase/DwnstrTrack.h
+++ b/RecoBase/DwnstrTrack.h
@@ -102,7 +102,7 @@ namespace rbex {
     inline int UserFlag() const { return fUserFlag; }
     
     inline std::vector<double> CovMatrix() const {return fCovXY;}
-    inline double CovMatrix(size_t i, size_t j) const {return fCovXY[5*i +j];} // No checks.. 
+    inline double CovMatrix(size_t i, size_t j) const {return fCovXY[NumParams()*i + j];} // stride follows matrix size (4x4 when NoMagnet)
     
     friend std::ostream& operator << (std::ostream& o, const DwnstrTrack& h);
   };

--- a/RecoUtils/RecoUtils.cxx
+++ b/RecoUtils/RecoUtils.cxx
@@ -302,6 +302,11 @@ namespace ru {
   n[1] = eigv[1][el];
   n[2] = eigv[2][el];
 
+  if (std::abs(n[2]) < 1e-12) {
+    mf::LogError("RecoUtils") << "Error: principal eigenvector has ~zero z-component; cannot parameterize line by z.";
+    return;  // outputs already initialised to 0, same contract as the el==-1 early return
+  }
+
   //we can create any point L on the line by varying t
 
   //create endpoints at first and last station z-position


### PR DESCRIPTION
Part of #303.

## Fixes

**`RecoBase/DwnstrTrack.h` — covariance stride mismatch.** `CovMatrix(i,j)` always read `fCovXY[5*i+j]`, but for no-magnet 4-parameter tracks `Reset(true)` resizes `fCovXY` to 16 and the producer (`SSDRecDwnstrTracksAutre`) fills it with stride 4 (`SetCovarianceMatrix(i*nPars + j)`). So every off-diagonal read on 4-param tracks returned the wrong element, and `(3,3)` read index 18 of a 16-element vector (out of bounds). The getter now uses `NumParams()*i + j`, matching the setter. A full call-site audit (all two-argument `CovMatrix(` uses are in `SSDDVertexFitFCNAutre.cxx`) confirmed all callers pass logical indices and none compensates for the old stride; the 5-parameter/magnet path is byte-for-byte unchanged. No other RecoBase class has this pattern (`VertexAutre` uses a true 2-D array).

**`RecoUtils/RecoUtils.cxx` — degenerate eigenvector guard.** `findLine` divides by the principal eigenvector's z-component without a guard; an xy-collinear point set gives `n[2] ≈ 0` and infinite endpoints. Added an early return (epsilon 1e-12 on a unit-normalized vector — far below any physical slope, above eigen-decomposition round-off) in the same style and output contract as the existing `el == -1` check: `lfirst`/`llast` stay zero-initialized, which the callers in `SingleTrackAlgo` already tolerate.

**`Geometry/Geometry.cxx` — portable `std::abs`.** `Detector::View()` used unqualified `abs(sin(...))` on doubles (×4). It currently resolves to a floating overload under GCC/libstdc++, but if it ever resolves to C `int abs(int)` (other toolchain/include order), every comparison `< 0.2` collapses and all sensors classify as X_VIEW. Now `std::abs`, with an explicit `<cmath>` include.

## Verification
The CovMatrix change is a deliberate correctness change for 4-param tracks only (audit in the description above); everything else is behavior-preserving. No local build environment and no repo CI — **a collaborator build before undrafting would be appreciated.**

🤖 Assisted by Claude Code (claude-fable-5)
